### PR TITLE
Update use of `any` to `unknown` where possible

### DIFF
--- a/src/Application.ts
+++ b/src/Application.ts
@@ -1,11 +1,12 @@
 import { Callback } from 'aws-lambda';
 import Router from './Router';
 import { RequestEvent, HandlerContext } from './request-response-types';
+import { StringUnknownMap } from './utils/common-types';
 import { Request, Response } from '.';
 
 export default class Application extends Router {
 
-   private _settings: { [k: string]: any } = {};
+   private _settings: StringUnknownMap = {};
 
    /**
     * Assigns setting `name` to `value`. You may store any value that you want, but
@@ -37,7 +38,7 @@ export default class Application extends Router {
     * @param name The name of the setting
     * @param val The value to assign to the setting
     */
-   public setSetting(name: string, val: any): Application {
+   public setSetting(name: string, val: unknown): Application {
       this._settings[name] = val;
 
       if (name === 'case sensitive routing') {
@@ -49,7 +50,7 @@ export default class Application extends Router {
    /**
     * See `app.setSetting(name, val)`.
     */
-   public getSetting(name: string): any {
+   public getSetting(name: string): unknown {
       return this._settings[name];
    }
 
@@ -88,7 +89,7 @@ export default class Application extends Router {
       const req = new Request(this, evt, context),
             resp = new Response(this, req, cb);
 
-      this.handle(undefined, req, resp, (err: any): void => {
+      this.handle(undefined, req, resp, (err: unknown): void => {
          // handler of last resort:
          if (err) {
             resp.sendStatus(500);

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -237,7 +237,7 @@ export default class Request {
     * Middleware can be plugged in to support body parsing, e.g. JSON and multi-part form
     * bodies.
     */
-   public body?: any;
+   public body?: unknown;
 
    private readonly _headers: StringArrayOfStringsMap;
    private readonly _event: RequestEvent;
@@ -331,7 +331,7 @@ export default class Request {
 
    /** EVENT PARSING FUNCTIONS */
 
-   private _parseBody(body: string | null): any {
+   private _parseBody(body: string | null): unknown {
       if (!body || _.isEmpty(body)) {
          return null;
       }

--- a/src/Response.ts
+++ b/src/Response.ts
@@ -390,7 +390,7 @@ export default class Response {
     *
     * @param o the object to send in the response
     */
-   public json(o: any): Response {
+   public json(o: unknown): Response {
       this._body = JSON.stringify(o);
       return this.type('application/json; charset=utf-8').end();
    }
@@ -411,9 +411,9 @@ export default class Response {
     *
     * @param o the object to send in the response
     */
-   public jsonp(o: any): Response {
+   public jsonp(o: unknown): Response {
       const queryParamName = this.app.getSetting('jsonp callback name') || 'callback',
-            callbackFunctionName = this._request.query[queryParamName];
+            callbackFunctionName = this._request.query[queryParamName as string];
 
       if (_.isString(callbackFunctionName)) {
          this._body = `/**/ typeof ${callbackFunctionName} === 'function' && ${callbackFunctionName}(${JSON.stringify(o)});`;

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -34,7 +34,7 @@ export default class Router implements IRouter {
    // If we do add it, we need to set the case-sensitivity of the sub-router it creates
    // using the case-sensitivity setting of this router.
 
-   public handle(originalErr: any, req: Request, resp: Response, done: NextCallback): void {
+   public handle(originalErr: unknown, req: Request, resp: Response, done: NextCallback): void {
       const processors = _.filter(this._processors, (p) => { return p.matches(req); });
 
       const go = _.reduce(processors.reverse(), (next: NextCallback, p: IProcessorChain): NextCallback => {

--- a/src/chains/ProcessorChain.ts
+++ b/src/chains/ProcessorChain.ts
@@ -3,7 +3,7 @@ import { ErrorHandlingRequestProcessor, NextCallback } from '../interfaces';
 import { Request, Response } from '..';
 
 export interface IProcessorChain {
-   run(err: any, req: Request, resp: Response, done: NextCallback): void;
+   run(err: unknown, req: Request, resp: Response, done: NextCallback): void;
 }
 
 export interface IRequestMatchingProcessorChain extends IProcessorChain {
@@ -18,7 +18,7 @@ export default class ProcessorChain implements IProcessorChain {
       this._subprocessors = subprocessors;
    }
 
-   public run(originalErr: any, req: Request, resp: Response, done: NextCallback): void {
+   public run(originalErr: unknown, req: Request, resp: Response, done: NextCallback): void {
       const subRequest = this._makeSubRequest(req);
 
       const run = _.reduce(this._subprocessors.slice().reverse(), (next: NextCallback, rp: ErrorHandlingRequestProcessor): NextCallback => {

--- a/src/chains/SubRouterProcessorChain.ts
+++ b/src/chains/SubRouterProcessorChain.ts
@@ -15,7 +15,7 @@ export class SubRouterProcessorChain implements IRequestMatchingProcessorChain {
       this._router = router;
    }
 
-   public run(err: any, req: Request, resp: Response, done: NextCallback): void {
+   public run(err: unknown, req: Request, resp: Response, done: NextCallback): void {
       const result = this._matcher.exec(req.path);
 
       if (!result || result.length === 0) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -13,7 +13,7 @@ import Response from './Response';
  * be handed over to the first error-handling request processor in the chain.
  */
 export interface NextCallback {
-   (err?: any): void;
+   (err?: unknown): void;
 }
 
 /**
@@ -67,7 +67,7 @@ export interface ErrorHandlingRequestProcessor {
     * @param next Callback that should be called when the handler is done with its work
     *             processing the request (see notes above)
     */
-   (err: any, req: Request, resp: Response, next: NextCallback): unknown;
+   (err: unknown, req: Request, resp: Response, next: NextCallback): unknown;
 }
 
 export type AnyRequestProcessor = RequestProcessor | ErrorHandlingRequestProcessor;
@@ -166,6 +166,6 @@ export interface IRouter {
     * not the first request processor to have handled the request, and a previous one
     * already generated an error).
     */
-   handle(err: any, req: Request, resp: Response, done: NextCallback): void;
+   handle(err: unknown, req: Request, resp: Response, done: NextCallback): void;
 
 }

--- a/src/utils/wrapRequestProcessor.ts
+++ b/src/utils/wrapRequestProcessor.ts
@@ -8,7 +8,7 @@ function isErrorHandler(rh: AnyRequestProcessor): rh is ErrorHandlingRequestProc
 
 export function wrapRequestProcessor(rp: AnyRequestProcessor): ErrorHandlingRequestProcessor {
    if (isErrorHandler(rp)) {
-      return (err: any, req: Request, resp: Response, next: NextCallback) => {
+      return (err: unknown, req: Request, resp: Response, next: NextCallback) => {
          if (err) {
             return rp(err, req, resp, next);
          }
@@ -19,7 +19,7 @@ export function wrapRequestProcessor(rp: AnyRequestProcessor): ErrorHandlingRequ
       };
    }
 
-   return (err: any, req: Request, resp: Response, next: NextCallback) => {
+   return (err: unknown, req: Request, resp: Response, next: NextCallback) => {
       if (err) {
          // If there's an error, regular request processors don't handle it, so we
          // simply call next so that we keep chaining down to the first real error

--- a/tests/chains/SubRouterProcessorChain.test.ts
+++ b/tests/chains/SubRouterProcessorChain.test.ts
@@ -16,7 +16,7 @@ class TestRouter extends Router {
       this._handler = handler;
    }
 
-   public handle(originalErr: any, req: Request, resp: Response, done: NextCallback): void {
+   public handle(originalErr: unknown, req: Request, resp: Response, done: NextCallback): void {
       this._handler(originalErr, req, resp, done);
    }
 

--- a/tests/test-utils/makeRequestProcessor.ts
+++ b/tests/test-utils/makeRequestProcessor.ts
@@ -33,7 +33,7 @@ export default function makeRequestProcessor(name: string, userOpts?: MakeFuncti
        rp: AnyRequestProcessor;
 
    if (opts.handlesErrors) {
-      rp = (err: any, _req: Request, _resp: Response, next: NextCallback): void => {
+      rp = (err: unknown, _req: Request, _resp: Response, next: NextCallback): void => {
          if (opts.throwsError) {
             throw new Error(`Error from "${name}"`);
          } else if (opts.callsNextWithError) {


### PR DESCRIPTION
The `unknown` type was introduced in TypeScript 3.0 as a type-safe
equivalent to `any`. Using `unknown` where possible helps ensure that
the type of a variable is checked before it is used.