### PR TITLE
Fix mime type lookup not having standard.json available

### DIFF
--- a/src/mime/mimeLookup.ts
+++ b/src/mime/mimeLookup.ts
@@ -1,7 +1,8 @@
 import _ from 'underscore';
+import MimeTypes from './standard.json';
 import { StringMap } from '../utils/common-types';
 
-const db = _.reduce(require('./standard.json'), (memo, extensions: string[], type: string): StringMap => {
+const db = _.reduce(MimeTypes, (memo, extensions: string[], type: string): StringMap => {
    _.each(extensions, (ext) => {
       memo[ext] = type;
    });


### PR DESCRIPTION
When building the `dist/esm` folder, the file `src/mime/standard.json`
was not getting copied into `dist/esm/mime/`. Thus, when someone
imported the module in their node project, Lambda Express could not be
initialized because it was missing a file that was being required. The
reason the file wasn't being copied into the dist was that it was being
required instead of imported.

Importing it also has the side effect of providing type inspection of
standard.json and thus making the `reduce` loop type safe.