### PR TITLE
Revert path-to-regexp to same version Express uses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4360,9 +4360,9 @@
          "dev": true
       },
       "path-to-regexp": {
-         "version": "3.0.0",
-         "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.0.0.tgz",
-         "integrity": "sha512-ZOtfhPttCrqp2M1PBBH4X13XlvnfhIwD7yCLx+GoGoXRPQyxGOTdQMpIzPSPKXAJT/JQrdfFrgdJOyAzvgpQ9A=="
+         "version": "0.1.7",
+         "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+         "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
       },
       "path-type": {
          "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
    },
    "dependencies": {
       "cookie": "0.3.1",
-      "path-to-regexp": "3.0.0",
+      "path-to-regexp": "0.1.7",
       "qs": "6.6.0",
       "tslib": "1.9.3",
       "underscore": "1.9.1"

--- a/src/chains/RouteMatchingProcessorChain.ts
+++ b/src/chains/RouteMatchingProcessorChain.ts
@@ -2,14 +2,18 @@ import _ from 'underscore';
 import ProcessorChain, { IRequestMatchingProcessorChain } from './ProcessorChain';
 import { ErrorHandlingRequestProcessor, PathParams } from '../interfaces';
 import { Request } from '..';
-import pathToRegexp from 'path-to-regexp';
 import { StringMap } from '../utils/common-types';
+const pathToRegexp = require('path-to-regexp');
+
+interface PathToRegexpKey {
+   [name: string]: string;
+}
 
 export class RouteMatchingProcessorChain extends ProcessorChain implements IRequestMatchingProcessorChain {
 
    private readonly _method: string | undefined;
    private readonly _matcher: RegExp;
-   private readonly _paramKeys: pathToRegexp.Key[] = [];
+   private readonly _paramKeys: PathToRegexpKey[] = [];
 
    public constructor(subprocessors: ErrorHandlingRequestProcessor[], path: PathParams, caseSensitive: boolean = false, method?: string) {
       super(subprocessors);

--- a/src/chains/SubRouterProcessorChain.ts
+++ b/src/chains/SubRouterProcessorChain.ts
@@ -1,17 +1,16 @@
 import { IRequestMatchingProcessorChain } from './ProcessorChain';
 import { PathParams, IRouter, NextCallback } from '../interfaces';
 import { Request, Response } from '..';
-import pathToRegexp from 'path-to-regexp';
+const pathToRegexp = require('path-to-regexp');
 
 export class SubRouterProcessorChain implements IRequestMatchingProcessorChain {
 
    private readonly _matcher: RegExp;
-   private readonly _paramKeys: pathToRegexp.Key[] = [];
    private readonly _router: IRouter;
 
    public constructor(path: PathParams, router: IRouter) {
       // TODO: case sensitivity settings (strict and end need to remain false here):
-      this._matcher = pathToRegexp(path, this._paramKeys, { sensitive: false, strict: false, end: false });
+      this._matcher = pathToRegexp(path, [], { sensitive: false, strict: false, end: false });
       this._router = router;
    }
 

--- a/tests/chains/RouteMatchingProcessorChain.test.ts
+++ b/tests/chains/RouteMatchingProcessorChain.test.ts
@@ -77,10 +77,10 @@ describe('RouteMatchingProcessorChain', () => {
          test('/users/:id', '/users/1234', { id: '1234' });
          test('/users/:id?', '/users', {});
          test('/users/:id?', '/users/1234', { id: '1234' });
-         test('/users/:path+', '/users', {});
-         test('/users/:path+', '/users/', {});
-         test('/users/:path+', '/users/usa/tx/austin', { path: 'usa/tx/austin' });
-         test('/users/:path+', '/users/usa/tx/austin/', { path: 'usa/tx/austin' });
+         test('/users/*', '/users', {});
+         test('/users/*', '/users/', {});
+         test('/users/*', '/users/usa/tx/austin', { '0': 'usa/tx/austin' });
+         test('/users/*', '/users/usa/tx/austin/', { '0': 'usa/tx/austin/' });
          test('/cars/:car/drivers/:driver/licenses/:license', '/cars/ford/drivers/jeremy/licenses/CM', {
             car: 'ford',
             driver: 'jeremy',

--- a/tests/chains/SubRouterProcessorChain.test.ts
+++ b/tests/chains/SubRouterProcessorChain.test.ts
@@ -77,9 +77,9 @@ describe('SubRouterProcessorChain', () => {
 
       it('runs with a proper sub-request', () => {
          test('/users', '/users', '/users');
-         test('/user(s*)', '/user', '/user');
-         test('/user(s*)/admins', '/user/admins', '/user/admins');
-         test('/user(s*)/admins', '/users/admins', '/users/admins');
+         test('/user(s?*)', '/user', '/user');
+         test('/user(s?*)/admins', '/user/admins', '/user/admins');
+         test('/user(s?*)/admins', '/users/admins', '/users/admins');
          test([ '/users', '/personnel' ], '/users', '/users');
          test([ '/users', '/personnel' ], '/personnel', '/personnel');
          test([ '/users', /\/person+el/ ], '/personnel', '/personnel');

--- a/tests/integration-tests.test.ts
+++ b/tests/integration-tests.test.ts
@@ -374,13 +374,7 @@ describe('integration tests', () => {
 
          app.addSubRouter('/cars', r1);
 
-         // TODO: we need to note / think about this difference from Express 4.x: Because
-         // we're using the latest path-to-regexp, it has a difference when it comes to
-         // `/*` - Express 4.x allows for regular expression characters anywhere in the
-         // path, but the latest path-to-regexp says that's considered a bug and it now
-         // only allows them in parameters. That said, Express adds a fast_star parameter
-         // for things that end in star, and maybe that's what we need to do here.
-         app.get('/(.*)', (_req: Request, resp: Response): void => {
+         app.get('/*', (_req: Request, resp: Response): void => {
             resp.send('everything else');
          });
 


### PR DESCRIPTION
There were a few differences between the version Express uses (0.1.7)
and the version we started out using (3.0.0). Notably, the support for
`/*` was drastically different. Since that one pattern will be used so
frequently, it didn't seem worth trying to maintain that difference as
it would negatively impact developers familiar with the `/*` pattern.

There was also a difference in the support of modifiers indicating how
many times a named parameter could appear (e.g. `/:path+` for params
like `/some/directory/and/file/path`).

The differences were clearly explained on the [path-to-regexp
homepage][1], but I originally thought it might be worth accepting those
differences or working around them. This doesn't seem feasible or worth
it, though.

[1]: https://github.com/pillarjs/path-to-regexp/blob/4eee1e15ba72d93c996bac4ae649a846eb326562/Readme.md#compatibility-with-express--4x