### PR TITLE
Fix coverage report for interfaces.ts and request-response-types.ts

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore next */
+
 import Request from './Request';
 import Response from './Response';
 

--- a/src/request-response-types.ts
+++ b/src/request-response-types.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore next */
+
 import {
    APIGatewayEventRequestContext as OrigAPIGatewayEventRequestContext,
    APIGatewayProxyEvent,


### PR DESCRIPTION
Both interfaces.ts and request-reponse-types.ts export types only and do
not export anything in the variable space (classes, constants,
variables, etc). Therefore, when istanbul / mocha / ts-node runs, there
is no JS output for those files, except for one line that is a helper
for importing ES modules that is inserted into every file when the
`esModuleInterop` TypeScript compiler option is `true`. Because these
two files do not export anything in the variable space, the TypeScript
compiler does not output corresponding `require` statements when they
are imported. Therefore, these two files are not required anywhere and
so the one JS statement inside them is not executed, and istanbul
reports one line not covered in them.

To fix this, we add `/* istanbul ignore next */` to the top of these two
files to tell istanbul to ignore the next statement in the file when
calculating code coverage. We use `ignore next` and not `ignore file`
(which would ignore the whole file) so that if something is added to the
file later that *is* in the variable space istanbul will still properly
report it as not covered.

Also, there must be a blank line in between the istanbul comment and the
first statement in the file or the TypeScript compiler will strip out
the comment and it will have no effect.