### PR TITLE
Add a safeguard for JS users when setting response headers

### DIFF
--- a/src/Response.ts
+++ b/src/Response.ts
@@ -54,6 +54,15 @@ export default class Response {
          this._headers[arg0] = [ arg1 ];
       } else if (isStringMap(arg0)) {
          _.each(arg0, (v, k) => { this.set(k, v); });
+      } else {
+         // This is here to help JS users who may not benefit from the type safety. If
+         // they were to do something like `resp.set('X-Foo', true)`, it would silently
+         // fail. Loudly failing seems better because at least they know - and we didn't
+         // have to guess at what their intent was.
+
+         // TODO: When we add logging to the library, it would probably be better to
+         // accomplish this by means of logging an error instead of throwing an error.
+         throw new Error(`Header value for "${arg0}" must be a string.`);
       }
       return this;
    }

--- a/tests/Response.test.ts
+++ b/tests/Response.test.ts
@@ -138,6 +138,15 @@ describe('Request', () => {
          }
       });
 
+      it('throws an error when passed two args and the second is not a string', () => {
+         // This is for JS-only functionality. TypeScript users will be safeguarded from
+         // doing this by type safety.
+         const val: any = true;
+
+         expect(() => { sampleResp.set('Foo', val); }).to
+            .throw('Header value for "Foo" must be a string.');
+      });
+
       describe('append', () => {
 
          it('handles when a header has not yet been set', () => {


### PR DESCRIPTION
We aren't adding many JS safeguards since we're providing type safety by
means of TypeScript. However, in this case, many users could easily have
been thrown off by trying to set response headers with non-string values
(e.g. booleans and numbers). Rather than a) failing silently, or b)
trying to convert those values for them, guessing at how they want them
converted, we will instead log an error to warn the developer of the
mistake.