### PR TITLE
feat(standards): add commit message linting and changelog generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ script:
    - node --version
    - npm --version
    - grunt standards
+   - commitlint-travis
    - grunt clean build
    - npm test
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ module.exports = (grunt) => {
       js: {
          gruntFile: 'Gruntfile.js',
          all: [
-            'Gruntfile.js',
+            './*.js',
             './src/**/*.js',
             './tests/**/*.js',
          ],

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/silvermine/lambda-express/badge.svg?branch=master)](https://coveralls.io/github/silvermine/lambda-express?branch=master)
 [![Dependency Status](https://david-dm.org/silvermine/lambda-express.svg)](https://david-dm.org/silvermine/lambda-express)
 [![Dev Dependency Status](https://david-dm.org/silvermine/lambda-express/dev-status.svg)](https://david-dm.org/silvermine/lambda-express#info=devDependencies&view=table)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 
 
 ## What?

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = { extends: [ '@commitlint/config-conventional' ] };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1241,6 +1241,12 @@
             }
          }
       },
+      "conventional-commit-types": {
+         "version": "2.2.0",
+         "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-2.2.0.tgz",
+         "integrity": "sha1-XblXOdbCEqy+e29lahG5QLqmiUY=",
+         "dev": true
+      },
       "conventional-commits-filter": {
          "version": "2.0.1",
          "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.1.tgz",
@@ -1646,6 +1652,19 @@
          "dev": true,
          "requires": {
             "array-find-index": "^1.0.1"
+         }
+      },
+      "cz-conventional-changelog": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-2.1.0.tgz",
+         "integrity": "sha1-L0vHOQ4yROTfKT5ro1Hkx0Cnx2Q=",
+         "dev": true,
+         "requires": {
+            "conventional-commit-types": "^2.0.0",
+            "lodash.map": "^4.5.1",
+            "longest": "^1.0.1",
+            "right-pad": "^1.0.1",
+            "word-wrap": "^1.0.3"
          }
       },
       "dargs": {
@@ -3830,6 +3849,12 @@
          "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
          "dev": true
       },
+      "lodash.map": {
+         "version": "4.6.0",
+         "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+         "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
+         "dev": true
+      },
       "lodash.template": {
          "version": "4.4.0",
          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
@@ -3865,6 +3890,12 @@
          "version": "2.7.5",
          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+         "dev": true
+      },
+      "longest": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+         "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
          "dev": true
       },
       "loud-rejection": {
@@ -5983,6 +6014,12 @@
          "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
          "dev": true
       },
+      "right-pad": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
+         "integrity": "sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=",
+         "dev": true
+      },
       "rimraf": {
          "version": "2.6.3",
          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -6955,6 +6992,12 @@
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+         "dev": true
+      },
+      "word-wrap": {
+         "version": "1.2.3",
+         "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+         "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
          "dev": true
       },
       "wordwrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -287,6 +287,16 @@
             "semver": "5.5.0"
          }
       },
+      "JSONStream": {
+         "version": "1.3.5",
+         "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+         "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+         "dev": true,
+         "requires": {
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
+         }
+      },
       "abbrev": {
          "version": "1.1.1",
          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -389,6 +399,12 @@
          "version": "2.1.1",
          "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
          "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+         "dev": true
+      },
+      "array-ify": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+         "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
          "dev": true
       },
       "array-slice": {
@@ -749,6 +765,23 @@
          "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
          "dev": true
       },
+      "cliui": {
+         "version": "4.1.0",
+         "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+         "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+         "dev": true,
+         "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+         }
+      },
+      "code-point-at": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+         "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+         "dev": true
+      },
       "coffeescript": {
          "version": "1.10.0",
          "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.10.0.tgz",
@@ -801,6 +834,16 @@
          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
          "dev": true
       },
+      "compare-func": {
+         "version": "1.3.2",
+         "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
+         "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
+         "dev": true,
+         "requires": {
+            "array-ify": "^1.0.0",
+            "dot-prop": "^3.0.0"
+         }
+      },
       "component-emitter": {
          "version": "1.2.1",
          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -813,11 +856,726 @@
          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
          "dev": true
       },
+      "concat-stream": {
+         "version": "1.6.2",
+         "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+         "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+         "dev": true,
+         "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+         }
+      },
       "continuable-cache": {
          "version": "0.3.1",
          "resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
          "integrity": "sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=",
          "dev": true
+      },
+      "conventional-changelog": {
+         "version": "3.0.6",
+         "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.0.6.tgz",
+         "integrity": "sha512-1b96x3G67lDKakRvMm+VvYGwgRk+C8aapHKL5iZ/TJzzD/RuyGA2diHNEsR+uPHmQ7/A4Ts7j6N+VNqUoOfksg==",
+         "dev": true,
+         "requires": {
+            "conventional-changelog-angular": "^5.0.3",
+            "conventional-changelog-atom": "^2.0.1",
+            "conventional-changelog-codemirror": "^2.0.1",
+            "conventional-changelog-core": "^3.1.6",
+            "conventional-changelog-ember": "^2.0.2",
+            "conventional-changelog-eslint": "^3.0.1",
+            "conventional-changelog-express": "^2.0.1",
+            "conventional-changelog-jquery": "^3.0.4",
+            "conventional-changelog-jshint": "^2.0.1",
+            "conventional-changelog-preset-loader": "^2.0.2"
+         }
+      },
+      "conventional-changelog-angular": {
+         "version": "5.0.3",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz",
+         "integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
+         "dev": true,
+         "requires": {
+            "compare-func": "^1.3.1",
+            "q": "^1.5.1"
+         }
+      },
+      "conventional-changelog-atom": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-2.0.1.tgz",
+         "integrity": "sha512-9BniJa4gLwL20Sm7HWSNXd0gd9c5qo49gCi8nylLFpqAHhkFTj7NQfROq3f1VpffRtzfTQp4VKU5nxbe2v+eZQ==",
+         "dev": true,
+         "requires": {
+            "q": "^1.5.1"
+         }
+      },
+      "conventional-changelog-codemirror": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-2.0.1.tgz",
+         "integrity": "sha512-23kT5IZWa+oNoUaDUzVXMYn60MCdOygTA2I+UjnOMiYVhZgmVwNd6ri/yDlmQGXHqbKhNR5NoXdBzSOSGxsgIQ==",
+         "dev": true,
+         "requires": {
+            "q": "^1.5.1"
+         }
+      },
+      "conventional-changelog-core": {
+         "version": "3.1.6",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.1.6.tgz",
+         "integrity": "sha512-5teTAZOtJ4HLR6384h50nPAaKdDr+IaU0rnD2Gg2C3MS7hKsEPH8pZxrDNqam9eOSPQg9tET6uZY79zzgSz+ig==",
+         "dev": true,
+         "requires": {
+            "conventional-changelog-writer": "^4.0.3",
+            "conventional-commits-parser": "^3.0.1",
+            "dateformat": "^3.0.0",
+            "get-pkg-repo": "^1.0.0",
+            "git-raw-commits": "2.0.0",
+            "git-remote-origin-url": "^2.0.0",
+            "git-semver-tags": "^2.0.2",
+            "lodash": "^4.2.1",
+            "normalize-package-data": "^2.3.5",
+            "q": "^1.5.1",
+            "read-pkg": "^3.0.0",
+            "read-pkg-up": "^3.0.0",
+            "through2": "^2.0.0"
+         },
+         "dependencies": {
+            "dateformat": {
+               "version": "3.0.3",
+               "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+               "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+               "dev": true
+            },
+            "find-up": {
+               "version": "2.1.0",
+               "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+               "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+               "dev": true,
+               "requires": {
+                  "locate-path": "^2.0.0"
+               }
+            },
+            "load-json-file": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+               "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+               "dev": true,
+               "requires": {
+                  "graceful-fs": "^4.1.2",
+                  "parse-json": "^4.0.0",
+                  "pify": "^3.0.0",
+                  "strip-bom": "^3.0.0"
+               }
+            },
+            "parse-json": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+               "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+               "dev": true,
+               "requires": {
+                  "error-ex": "^1.3.1",
+                  "json-parse-better-errors": "^1.0.1"
+               }
+            },
+            "path-type": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+               "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+               "dev": true,
+               "requires": {
+                  "pify": "^3.0.0"
+               }
+            },
+            "pify": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+               "dev": true
+            },
+            "read-pkg": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+               "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+               "dev": true,
+               "requires": {
+                  "load-json-file": "^4.0.0",
+                  "normalize-package-data": "^2.3.2",
+                  "path-type": "^3.0.0"
+               }
+            },
+            "read-pkg-up": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+               "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+               "dev": true,
+               "requires": {
+                  "find-up": "^2.0.0",
+                  "read-pkg": "^3.0.0"
+               }
+            },
+            "strip-bom": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+               "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+               "dev": true
+            }
+         }
+      },
+      "conventional-changelog-ember": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-2.0.2.tgz",
+         "integrity": "sha512-qtZbA3XefO/n6DDmkYywDYi6wDKNNc98MMl2F9PKSaheJ25Trpi3336W8fDlBhq0X+EJRuseceAdKLEMmuX2tg==",
+         "dev": true,
+         "requires": {
+            "q": "^1.5.1"
+         }
+      },
+      "conventional-changelog-eslint": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-3.0.1.tgz",
+         "integrity": "sha512-yH3+bYrtvgKxSFChUBQnKNh9/U9kN2JElYBm253VpYs5wXhPHVc9ENcuVGWijh24nnOkei7wEJmnmUzgZ4ok+A==",
+         "dev": true,
+         "requires": {
+            "q": "^1.5.1"
+         }
+      },
+      "conventional-changelog-express": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-2.0.1.tgz",
+         "integrity": "sha512-G6uCuCaQhLxdb4eEfAIHpcfcJ2+ao3hJkbLrw/jSK/eROeNfnxCJasaWdDAfFkxsbpzvQT4W01iSynU3OoPLIw==",
+         "dev": true,
+         "requires": {
+            "q": "^1.5.1"
+         }
+      },
+      "conventional-changelog-jquery": {
+         "version": "3.0.4",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-3.0.4.tgz",
+         "integrity": "sha512-IVJGI3MseYoY6eybknnTf9WzeQIKZv7aNTm2KQsiFVJH21bfP2q7XVjfoMibdCg95GmgeFlaygMdeoDDa+ZbEQ==",
+         "dev": true,
+         "requires": {
+            "q": "^1.5.1"
+         }
+      },
+      "conventional-changelog-jshint": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.1.tgz",
+         "integrity": "sha512-kRFJsCOZzPFm2tzRHULWP4tauGMvccOlXYf3zGeuSW4U0mZhk5NsjnRZ7xFWrTFPlCLV+PNmHMuXp5atdoZmEg==",
+         "dev": true,
+         "requires": {
+            "compare-func": "^1.3.1",
+            "q": "^1.5.1"
+         }
+      },
+      "conventional-changelog-preset-loader": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.0.2.tgz",
+         "integrity": "sha512-pBY+qnUoJPXAXXqVGwQaVmcye05xi6z231QM98wHWamGAmu/ghkBprQAwmF5bdmyobdVxiLhPY3PrCfSeUNzRQ==",
+         "dev": true
+      },
+      "conventional-changelog-writer": {
+         "version": "4.0.3",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.3.tgz",
+         "integrity": "sha512-bIlpSiQtQZ1+nDVHEEh798Erj2jhN/wEjyw9sfxY9es6h7pREE5BNJjfv0hXGH/FTrAsEpHUq4xzK99eePpwuA==",
+         "dev": true,
+         "requires": {
+            "compare-func": "^1.3.1",
+            "conventional-commits-filter": "^2.0.1",
+            "dateformat": "^3.0.0",
+            "handlebars": "^4.1.0",
+            "json-stringify-safe": "^5.0.1",
+            "lodash": "^4.2.1",
+            "meow": "^4.0.0",
+            "semver": "^5.5.0",
+            "split": "^1.0.0",
+            "through2": "^2.0.0"
+         },
+         "dependencies": {
+            "camelcase": {
+               "version": "4.1.0",
+               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+               "dev": true
+            },
+            "camelcase-keys": {
+               "version": "4.2.0",
+               "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+               "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+               "dev": true,
+               "requires": {
+                  "camelcase": "^4.1.0",
+                  "map-obj": "^2.0.0",
+                  "quick-lru": "^1.0.0"
+               }
+            },
+            "dateformat": {
+               "version": "3.0.3",
+               "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+               "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+               "dev": true
+            },
+            "find-up": {
+               "version": "2.1.0",
+               "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+               "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+               "dev": true,
+               "requires": {
+                  "locate-path": "^2.0.0"
+               }
+            },
+            "indent-string": {
+               "version": "3.2.0",
+               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+               "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+               "dev": true
+            },
+            "load-json-file": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+               "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+               "dev": true,
+               "requires": {
+                  "graceful-fs": "^4.1.2",
+                  "parse-json": "^4.0.0",
+                  "pify": "^3.0.0",
+                  "strip-bom": "^3.0.0"
+               }
+            },
+            "map-obj": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+               "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+               "dev": true
+            },
+            "meow": {
+               "version": "4.0.1",
+               "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+               "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+               "dev": true,
+               "requires": {
+                  "camelcase-keys": "^4.0.0",
+                  "decamelize-keys": "^1.0.0",
+                  "loud-rejection": "^1.0.0",
+                  "minimist": "^1.1.3",
+                  "minimist-options": "^3.0.1",
+                  "normalize-package-data": "^2.3.4",
+                  "read-pkg-up": "^3.0.0",
+                  "redent": "^2.0.0",
+                  "trim-newlines": "^2.0.0"
+               }
+            },
+            "parse-json": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+               "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+               "dev": true,
+               "requires": {
+                  "error-ex": "^1.3.1",
+                  "json-parse-better-errors": "^1.0.1"
+               }
+            },
+            "path-type": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+               "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+               "dev": true,
+               "requires": {
+                  "pify": "^3.0.0"
+               }
+            },
+            "pify": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+               "dev": true
+            },
+            "read-pkg": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+               "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+               "dev": true,
+               "requires": {
+                  "load-json-file": "^4.0.0",
+                  "normalize-package-data": "^2.3.2",
+                  "path-type": "^3.0.0"
+               }
+            },
+            "read-pkg-up": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+               "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+               "dev": true,
+               "requires": {
+                  "find-up": "^2.0.0",
+                  "read-pkg": "^3.0.0"
+               }
+            },
+            "redent": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+               "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+               "dev": true,
+               "requires": {
+                  "indent-string": "^3.0.0",
+                  "strip-indent": "^2.0.0"
+               }
+            },
+            "strip-bom": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+               "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+               "dev": true
+            },
+            "strip-indent": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+               "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+               "dev": true
+            },
+            "trim-newlines": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+               "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+               "dev": true
+            }
+         }
+      },
+      "conventional-commits-filter": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.1.tgz",
+         "integrity": "sha512-92OU8pz/977udhBjgPEbg3sbYzIxMDFTlQT97w7KdhR9igNqdJvy8smmedAAgn4tPiqseFloKkrVfbXCVd+E7A==",
+         "dev": true,
+         "requires": {
+            "is-subset": "^0.1.1",
+            "modify-values": "^1.0.0"
+         }
+      },
+      "conventional-commits-parser": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.1.tgz",
+         "integrity": "sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==",
+         "dev": true,
+         "requires": {
+            "JSONStream": "^1.0.4",
+            "is-text-path": "^1.0.0",
+            "lodash": "^4.2.1",
+            "meow": "^4.0.0",
+            "split2": "^2.0.0",
+            "through2": "^2.0.0",
+            "trim-off-newlines": "^1.0.0"
+         },
+         "dependencies": {
+            "camelcase": {
+               "version": "4.1.0",
+               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+               "dev": true
+            },
+            "camelcase-keys": {
+               "version": "4.2.0",
+               "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+               "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+               "dev": true,
+               "requires": {
+                  "camelcase": "^4.1.0",
+                  "map-obj": "^2.0.0",
+                  "quick-lru": "^1.0.0"
+               }
+            },
+            "find-up": {
+               "version": "2.1.0",
+               "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+               "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+               "dev": true,
+               "requires": {
+                  "locate-path": "^2.0.0"
+               }
+            },
+            "indent-string": {
+               "version": "3.2.0",
+               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+               "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+               "dev": true
+            },
+            "load-json-file": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+               "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+               "dev": true,
+               "requires": {
+                  "graceful-fs": "^4.1.2",
+                  "parse-json": "^4.0.0",
+                  "pify": "^3.0.0",
+                  "strip-bom": "^3.0.0"
+               }
+            },
+            "map-obj": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+               "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+               "dev": true
+            },
+            "meow": {
+               "version": "4.0.1",
+               "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+               "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+               "dev": true,
+               "requires": {
+                  "camelcase-keys": "^4.0.0",
+                  "decamelize-keys": "^1.0.0",
+                  "loud-rejection": "^1.0.0",
+                  "minimist": "^1.1.3",
+                  "minimist-options": "^3.0.1",
+                  "normalize-package-data": "^2.3.4",
+                  "read-pkg-up": "^3.0.0",
+                  "redent": "^2.0.0",
+                  "trim-newlines": "^2.0.0"
+               }
+            },
+            "parse-json": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+               "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+               "dev": true,
+               "requires": {
+                  "error-ex": "^1.3.1",
+                  "json-parse-better-errors": "^1.0.1"
+               }
+            },
+            "path-type": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+               "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+               "dev": true,
+               "requires": {
+                  "pify": "^3.0.0"
+               }
+            },
+            "pify": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+               "dev": true
+            },
+            "read-pkg": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+               "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+               "dev": true,
+               "requires": {
+                  "load-json-file": "^4.0.0",
+                  "normalize-package-data": "^2.3.2",
+                  "path-type": "^3.0.0"
+               }
+            },
+            "read-pkg-up": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+               "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+               "dev": true,
+               "requires": {
+                  "find-up": "^2.0.0",
+                  "read-pkg": "^3.0.0"
+               }
+            },
+            "redent": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+               "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+               "dev": true,
+               "requires": {
+                  "indent-string": "^3.0.0",
+                  "strip-indent": "^2.0.0"
+               }
+            },
+            "split2": {
+               "version": "2.2.0",
+               "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+               "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+               "dev": true,
+               "requires": {
+                  "through2": "^2.0.2"
+               }
+            },
+            "strip-bom": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+               "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+               "dev": true
+            },
+            "strip-indent": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+               "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+               "dev": true
+            },
+            "trim-newlines": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+               "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+               "dev": true
+            }
+         }
+      },
+      "conventional-recommended-bump": {
+         "version": "4.0.4",
+         "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-4.0.4.tgz",
+         "integrity": "sha512-9mY5Yoblq+ZMqJpBzgS+RpSq+SUfP2miOR3H/NR9drGf08WCrY9B6HAGJZEm6+ThsVP917VHAahSOjM6k1vhPg==",
+         "dev": true,
+         "requires": {
+            "concat-stream": "^1.6.0",
+            "conventional-changelog-preset-loader": "^2.0.2",
+            "conventional-commits-filter": "^2.0.1",
+            "conventional-commits-parser": "^3.0.1",
+            "git-raw-commits": "2.0.0",
+            "git-semver-tags": "^2.0.2",
+            "meow": "^4.0.0",
+            "q": "^1.5.1"
+         },
+         "dependencies": {
+            "camelcase": {
+               "version": "4.1.0",
+               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+               "dev": true
+            },
+            "camelcase-keys": {
+               "version": "4.2.0",
+               "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+               "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+               "dev": true,
+               "requires": {
+                  "camelcase": "^4.1.0",
+                  "map-obj": "^2.0.0",
+                  "quick-lru": "^1.0.0"
+               }
+            },
+            "find-up": {
+               "version": "2.1.0",
+               "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+               "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+               "dev": true,
+               "requires": {
+                  "locate-path": "^2.0.0"
+               }
+            },
+            "indent-string": {
+               "version": "3.2.0",
+               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+               "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+               "dev": true
+            },
+            "load-json-file": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+               "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+               "dev": true,
+               "requires": {
+                  "graceful-fs": "^4.1.2",
+                  "parse-json": "^4.0.0",
+                  "pify": "^3.0.0",
+                  "strip-bom": "^3.0.0"
+               }
+            },
+            "map-obj": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+               "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+               "dev": true
+            },
+            "meow": {
+               "version": "4.0.1",
+               "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+               "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+               "dev": true,
+               "requires": {
+                  "camelcase-keys": "^4.0.0",
+                  "decamelize-keys": "^1.0.0",
+                  "loud-rejection": "^1.0.0",
+                  "minimist": "^1.1.3",
+                  "minimist-options": "^3.0.1",
+                  "normalize-package-data": "^2.3.4",
+                  "read-pkg-up": "^3.0.0",
+                  "redent": "^2.0.0",
+                  "trim-newlines": "^2.0.0"
+               }
+            },
+            "parse-json": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+               "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+               "dev": true,
+               "requires": {
+                  "error-ex": "^1.3.1",
+                  "json-parse-better-errors": "^1.0.1"
+               }
+            },
+            "path-type": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+               "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+               "dev": true,
+               "requires": {
+                  "pify": "^3.0.0"
+               }
+            },
+            "pify": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+               "dev": true
+            },
+            "read-pkg": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+               "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+               "dev": true,
+               "requires": {
+                  "load-json-file": "^4.0.0",
+                  "normalize-package-data": "^2.3.2",
+                  "path-type": "^3.0.0"
+               }
+            },
+            "read-pkg-up": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+               "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+               "dev": true,
+               "requires": {
+                  "find-up": "^2.0.0",
+                  "read-pkg": "^3.0.0"
+               }
+            },
+            "redent": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+               "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+               "dev": true,
+               "requires": {
+                  "indent-string": "^3.0.0",
+                  "strip-indent": "^2.0.0"
+               }
+            },
+            "strip-bom": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+               "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+               "dev": true
+            },
+            "strip-indent": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+               "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+               "dev": true
+            },
+            "trim-newlines": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+               "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+               "dev": true
+            }
+         }
       },
       "cookie": {
          "version": "0.3.1",
@@ -890,6 +1648,15 @@
             "array-find-index": "^1.0.1"
          }
       },
+      "dargs": {
+         "version": "4.1.0",
+         "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
+         "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
+         "dev": true,
+         "requires": {
+            "number-is-nan": "^1.0.0"
+         }
+      },
       "dashdash": {
          "version": "1.14.1",
          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -923,6 +1690,16 @@
          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
          "dev": true
+      },
+      "decamelize-keys": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+         "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+         "dev": true,
+         "requires": {
+            "decamelize": "^1.1.0",
+            "map-obj": "^1.0.0"
+         }
       },
       "decode-uri-component": {
          "version": "0.2.0",
@@ -998,6 +1775,18 @@
          "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
          "dev": true
       },
+      "detect-indent": {
+         "version": "5.0.0",
+         "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+         "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
+         "dev": true
+      },
+      "detect-newline": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+         "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+         "dev": true
+      },
       "diff": {
          "version": "3.5.0",
          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -1011,6 +1800,36 @@
          "dev": true,
          "requires": {
             "esutils": "^2.0.2"
+         }
+      },
+      "dot-prop": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+         "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+         "dev": true,
+         "requires": {
+            "is-obj": "^1.0.0"
+         }
+      },
+      "dotgitignore": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/dotgitignore/-/dotgitignore-1.0.3.tgz",
+         "integrity": "sha512-eu5XjSstm0WXQsARgo6kPjkINYZlOUW+z/KtAAIBjHa5mUpMPrxJytbPIndWz6GubBuuuH5ljtVcXKnVnH5q8w==",
+         "dev": true,
+         "requires": {
+            "find-up": "^2.1.0",
+            "minimatch": "^3.0.4"
+         },
+         "dependencies": {
+            "find-up": {
+               "version": "2.1.0",
+               "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+               "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+               "dev": true,
+               "requires": {
+                  "locate-path": "^2.0.0"
+               }
+            }
          }
       },
       "duplexify": {
@@ -1241,6 +2060,21 @@
          "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
          "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
          "dev": true
+      },
+      "execa": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+         "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+         "dev": true,
+         "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+         }
       },
       "exit": {
          "version": "0.1.2",
@@ -1576,6 +2410,15 @@
             "map-cache": "^0.2.2"
          }
       },
+      "fs-access": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+         "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
+         "dev": true,
+         "requires": {
+            "null-check": "^1.0.0"
+         }
+      },
       "fs.realpath": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1597,17 +2440,57 @@
             "globule": "^1.0.0"
          }
       },
+      "get-caller-file": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+         "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+         "dev": true
+      },
       "get-func-name": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
          "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
          "dev": true
       },
+      "get-pkg-repo": {
+         "version": "1.4.0",
+         "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
+         "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
+         "dev": true,
+         "requires": {
+            "hosted-git-info": "^2.1.4",
+            "meow": "^3.3.0",
+            "normalize-package-data": "^2.3.0",
+            "parse-github-repo-url": "^1.3.0",
+            "through2": "^2.0.0"
+         }
+      },
       "get-stdin": {
          "version": "4.0.1",
          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
          "dev": true
+      },
+      "get-stream": {
+         "version": "4.1.0",
+         "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+         "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+         "dev": true,
+         "requires": {
+            "pump": "^3.0.0"
+         },
+         "dependencies": {
+            "pump": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+               "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+               "dev": true,
+               "requires": {
+                  "end-of-stream": "^1.1.0",
+                  "once": "^1.3.1"
+               }
+            }
+         }
       },
       "get-value": {
          "version": "2.0.6",
@@ -1628,6 +2511,343 @@
          "dev": true,
          "requires": {
             "assert-plus": "^1.0.0"
+         }
+      },
+      "git-raw-commits": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.0.tgz",
+         "integrity": "sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==",
+         "dev": true,
+         "requires": {
+            "dargs": "^4.0.1",
+            "lodash.template": "^4.0.2",
+            "meow": "^4.0.0",
+            "split2": "^2.0.0",
+            "through2": "^2.0.0"
+         },
+         "dependencies": {
+            "camelcase": {
+               "version": "4.1.0",
+               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+               "dev": true
+            },
+            "camelcase-keys": {
+               "version": "4.2.0",
+               "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+               "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+               "dev": true,
+               "requires": {
+                  "camelcase": "^4.1.0",
+                  "map-obj": "^2.0.0",
+                  "quick-lru": "^1.0.0"
+               }
+            },
+            "find-up": {
+               "version": "2.1.0",
+               "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+               "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+               "dev": true,
+               "requires": {
+                  "locate-path": "^2.0.0"
+               }
+            },
+            "indent-string": {
+               "version": "3.2.0",
+               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+               "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+               "dev": true
+            },
+            "load-json-file": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+               "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+               "dev": true,
+               "requires": {
+                  "graceful-fs": "^4.1.2",
+                  "parse-json": "^4.0.0",
+                  "pify": "^3.0.0",
+                  "strip-bom": "^3.0.0"
+               }
+            },
+            "map-obj": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+               "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+               "dev": true
+            },
+            "meow": {
+               "version": "4.0.1",
+               "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+               "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+               "dev": true,
+               "requires": {
+                  "camelcase-keys": "^4.0.0",
+                  "decamelize-keys": "^1.0.0",
+                  "loud-rejection": "^1.0.0",
+                  "minimist": "^1.1.3",
+                  "minimist-options": "^3.0.1",
+                  "normalize-package-data": "^2.3.4",
+                  "read-pkg-up": "^3.0.0",
+                  "redent": "^2.0.0",
+                  "trim-newlines": "^2.0.0"
+               }
+            },
+            "parse-json": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+               "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+               "dev": true,
+               "requires": {
+                  "error-ex": "^1.3.1",
+                  "json-parse-better-errors": "^1.0.1"
+               }
+            },
+            "path-type": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+               "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+               "dev": true,
+               "requires": {
+                  "pify": "^3.0.0"
+               }
+            },
+            "pify": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+               "dev": true
+            },
+            "read-pkg": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+               "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+               "dev": true,
+               "requires": {
+                  "load-json-file": "^4.0.0",
+                  "normalize-package-data": "^2.3.2",
+                  "path-type": "^3.0.0"
+               }
+            },
+            "read-pkg-up": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+               "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+               "dev": true,
+               "requires": {
+                  "find-up": "^2.0.0",
+                  "read-pkg": "^3.0.0"
+               }
+            },
+            "redent": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+               "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+               "dev": true,
+               "requires": {
+                  "indent-string": "^3.0.0",
+                  "strip-indent": "^2.0.0"
+               }
+            },
+            "split2": {
+               "version": "2.2.0",
+               "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+               "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+               "dev": true,
+               "requires": {
+                  "through2": "^2.0.2"
+               }
+            },
+            "strip-bom": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+               "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+               "dev": true
+            },
+            "strip-indent": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+               "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+               "dev": true
+            },
+            "trim-newlines": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+               "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+               "dev": true
+            }
+         }
+      },
+      "git-remote-origin-url": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
+         "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
+         "dev": true,
+         "requires": {
+            "gitconfiglocal": "^1.0.0",
+            "pify": "^2.3.0"
+         }
+      },
+      "git-semver-tags": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-2.0.2.tgz",
+         "integrity": "sha512-34lMF7Yo1xEmsK2EkbArdoU79umpvm0MfzaDkSNYSJqtM5QLAVTPWgpiXSVI5o/O9EvZPSrP4Zvnec/CqhSd5w==",
+         "dev": true,
+         "requires": {
+            "meow": "^4.0.0",
+            "semver": "^5.5.0"
+         },
+         "dependencies": {
+            "camelcase": {
+               "version": "4.1.0",
+               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+               "dev": true
+            },
+            "camelcase-keys": {
+               "version": "4.2.0",
+               "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+               "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+               "dev": true,
+               "requires": {
+                  "camelcase": "^4.1.0",
+                  "map-obj": "^2.0.0",
+                  "quick-lru": "^1.0.0"
+               }
+            },
+            "find-up": {
+               "version": "2.1.0",
+               "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+               "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+               "dev": true,
+               "requires": {
+                  "locate-path": "^2.0.0"
+               }
+            },
+            "indent-string": {
+               "version": "3.2.0",
+               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+               "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+               "dev": true
+            },
+            "load-json-file": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+               "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+               "dev": true,
+               "requires": {
+                  "graceful-fs": "^4.1.2",
+                  "parse-json": "^4.0.0",
+                  "pify": "^3.0.0",
+                  "strip-bom": "^3.0.0"
+               }
+            },
+            "map-obj": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+               "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+               "dev": true
+            },
+            "meow": {
+               "version": "4.0.1",
+               "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+               "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+               "dev": true,
+               "requires": {
+                  "camelcase-keys": "^4.0.0",
+                  "decamelize-keys": "^1.0.0",
+                  "loud-rejection": "^1.0.0",
+                  "minimist": "^1.1.3",
+                  "minimist-options": "^3.0.1",
+                  "normalize-package-data": "^2.3.4",
+                  "read-pkg-up": "^3.0.0",
+                  "redent": "^2.0.0",
+                  "trim-newlines": "^2.0.0"
+               }
+            },
+            "parse-json": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+               "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+               "dev": true,
+               "requires": {
+                  "error-ex": "^1.3.1",
+                  "json-parse-better-errors": "^1.0.1"
+               }
+            },
+            "path-type": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+               "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+               "dev": true,
+               "requires": {
+                  "pify": "^3.0.0"
+               }
+            },
+            "pify": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+               "dev": true
+            },
+            "read-pkg": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+               "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+               "dev": true,
+               "requires": {
+                  "load-json-file": "^4.0.0",
+                  "normalize-package-data": "^2.3.2",
+                  "path-type": "^3.0.0"
+               }
+            },
+            "read-pkg-up": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+               "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+               "dev": true,
+               "requires": {
+                  "find-up": "^2.0.0",
+                  "read-pkg": "^3.0.0"
+               }
+            },
+            "redent": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+               "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+               "dev": true,
+               "requires": {
+                  "indent-string": "^3.0.0",
+                  "strip-indent": "^2.0.0"
+               }
+            },
+            "strip-bom": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+               "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+               "dev": true
+            },
+            "strip-indent": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+               "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+               "dev": true
+            },
+            "trim-newlines": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+               "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+               "dev": true
+            }
+         }
+      },
+      "gitconfiglocal": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
+         "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
+         "dev": true,
+         "requires": {
+            "ini": "^1.3.2"
          }
       },
       "glob": {
@@ -2125,6 +3345,12 @@
          "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
          "dev": true
       },
+      "invert-kv": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+         "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+         "dev": true
+      },
       "is-absolute": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
@@ -2271,6 +3497,18 @@
             }
          }
       },
+      "is-obj": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+         "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+         "dev": true
+      },
+      "is-plain-obj": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+         "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+         "dev": true
+      },
       "is-plain-object": {
          "version": "2.0.4",
          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -2293,6 +3531,27 @@
          "dev": true,
          "requires": {
             "is-unc-path": "^1.0.0"
+         }
+      },
+      "is-stream": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+         "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+         "dev": true
+      },
+      "is-subset": {
+         "version": "0.1.1",
+         "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+         "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+         "dev": true
+      },
+      "is-text-path": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+         "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+         "dev": true,
+         "requires": {
+            "text-extensions": "^1.0.0"
          }
       },
       "is-typedarray": {
@@ -2395,6 +3654,12 @@
          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
          "dev": true
       },
+      "json-parse-better-errors": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+         "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+         "dev": true
+      },
       "json-schema": {
          "version": "0.2.3",
          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -2417,6 +3682,12 @@
          "version": "5.0.1",
          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+         "dev": true
+      },
+      "jsonparse": {
+         "version": "1.3.1",
+         "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+         "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
          "dev": true
       },
       "jsprim": {
@@ -2442,6 +3713,15 @@
          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
          "dev": true
+      },
+      "lcid": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+         "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+         "dev": true,
+         "requires": {
+            "invert-kv": "^2.0.0"
+         }
       },
       "lcov-parse": {
          "version": "0.0.10",
@@ -2508,10 +3788,34 @@
             "strip-bom": "^2.0.0"
          }
       },
+      "locate-path": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+         "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+         "dev": true,
+         "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+         },
+         "dependencies": {
+            "path-exists": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+               "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+               "dev": true
+            }
+         }
+      },
       "lodash": {
          "version": "4.17.11",
          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+         "dev": true
+      },
+      "lodash._reinterpolate": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+         "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
          "dev": true
       },
       "lodash.assign": {
@@ -2525,6 +3829,25 @@
          "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
          "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
          "dev": true
+      },
+      "lodash.template": {
+         "version": "4.4.0",
+         "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+         "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+         "dev": true,
+         "requires": {
+            "lodash._reinterpolate": "~3.0.0",
+            "lodash.templatesettings": "^4.0.0"
+         }
+      },
+      "lodash.templatesettings": {
+         "version": "4.1.0",
+         "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+         "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+         "dev": true,
+         "requires": {
+            "lodash._reinterpolate": "~3.0.0"
+         }
       },
       "lodash.unescape": {
          "version": "4.0.1",
@@ -2569,6 +3892,15 @@
             "kind-of": "^6.0.2"
          }
       },
+      "map-age-cleaner": {
+         "version": "0.1.3",
+         "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+         "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+         "dev": true,
+         "requires": {
+            "p-defer": "^1.0.0"
+         }
+      },
       "map-cache": {
          "version": "0.2.2",
          "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -2588,6 +3920,17 @@
          "dev": true,
          "requires": {
             "object-visit": "^1.0.0"
+         }
+      },
+      "mem": {
+         "version": "4.1.0",
+         "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
+         "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
+         "dev": true,
+         "requires": {
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^1.0.0",
+            "p-is-promise": "^2.0.0"
          }
       },
       "meow": {
@@ -2664,6 +4007,16 @@
          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
          "dev": true
+      },
+      "minimist-options": {
+         "version": "3.0.2",
+         "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+         "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+         "dev": true,
+         "requires": {
+            "arrify": "^1.0.1",
+            "is-plain-obj": "^1.1.0"
+         }
       },
       "mixin-deep": {
          "version": "1.3.1",
@@ -2755,6 +4108,12 @@
                }
             }
          }
+      },
+      "modify-values": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+         "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+         "dev": true
       },
       "ms": {
          "version": "2.0.0",
@@ -2858,6 +4217,21 @@
             "semver": "2 || 3 || 4 || 5",
             "validate-npm-package-license": "^3.0.1"
          }
+      },
+      "npm-run-path": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+         "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+         "dev": true,
+         "requires": {
+            "path-key": "^2.0.0"
+         }
+      },
+      "null-check": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
+         "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
+         "dev": true
       },
       "number-is-nan": {
          "version": "1.0.1",
@@ -4101,6 +5475,17 @@
          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
          "dev": true
       },
+      "os-locale": {
+         "version": "3.1.0",
+         "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+         "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+         "dev": true,
+         "requires": {
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
+         }
+      },
       "os-tmpdir": {
          "version": "1.0.2",
          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -4116,6 +5501,48 @@
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
          }
+      },
+      "p-defer": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+         "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+         "dev": true
+      },
+      "p-finally": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+         "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+         "dev": true
+      },
+      "p-is-promise": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+         "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
+         "dev": true
+      },
+      "p-limit": {
+         "version": "1.3.0",
+         "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+         "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+         "dev": true,
+         "requires": {
+            "p-try": "^1.0.0"
+         }
+      },
+      "p-locate": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+         "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+         "dev": true,
+         "requires": {
+            "p-limit": "^1.1.0"
+         }
+      },
+      "p-try": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+         "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+         "dev": true
       },
       "pad-stream": {
          "version": "1.2.0",
@@ -4149,6 +5576,12 @@
             "map-cache": "^0.2.0",
             "path-root": "^0.1.1"
          }
+      },
+      "parse-github-repo-url": {
+         "version": "1.4.1",
+         "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
+         "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
+         "dev": true
       },
       "parse-json": {
          "version": "2.2.0",
@@ -4325,10 +5758,22 @@
          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
          "dev": true
       },
+      "q": {
+         "version": "1.5.1",
+         "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+         "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+         "dev": true
+      },
       "qs": {
          "version": "6.6.0",
          "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
          "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
+      },
+      "quick-lru": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+         "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+         "dev": true
       },
       "raw-body": {
          "version": "1.1.7",
@@ -4476,6 +5921,18 @@
             }
          }
       },
+      "require-directory": {
+         "version": "2.1.1",
+         "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+         "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+         "dev": true
+      },
+      "require-main-filename": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+         "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+         "dev": true
+      },
       "requireindex": {
          "version": "1.2.0",
          "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
@@ -4606,6 +6063,12 @@
          "version": "5.5.0",
          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+         "dev": true
+      },
+      "set-blocking": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+         "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
          "dev": true
       },
       "set-value": {
@@ -4860,6 +6323,15 @@
          "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
          "dev": true
       },
+      "split": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+         "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+         "dev": true,
+         "requires": {
+            "through": "2"
+         }
+      },
       "split-string": {
          "version": "3.1.0",
          "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -4899,6 +6371,25 @@
             "jsbn": "~0.1.0",
             "safer-buffer": "^2.0.2",
             "tweetnacl": "~0.14.0"
+         }
+      },
+      "standard-version": {
+         "version": "git+https://github.com/jthomerson/standard-version.git#44f6381466a5a285a087fe40f468b3b8b3bd0810",
+         "from": "git+https://github.com/jthomerson/standard-version.git#fix-305-header-repeat",
+         "dev": true,
+         "requires": {
+            "chalk": "^2.4.1",
+            "conventional-changelog": "^3.0.6",
+            "conventional-recommended-bump": "^4.0.4",
+            "detect-indent": "^5.0.0",
+            "detect-newline": "^2.1.0",
+            "dotgitignore": "^1.0.3",
+            "figures": "^2.0.0",
+            "fs-access": "^1.0.0",
+            "git-semver-tags": "^2.0.2",
+            "semver": "^5.2.0",
+            "stringify-package": "^1.0.0",
+            "yargs": "^12.0.2"
          }
       },
       "static-extend": {
@@ -4953,6 +6444,12 @@
             "safe-buffer": "~5.1.0"
          }
       },
+      "stringify-package": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.0.tgz",
+         "integrity": "sha512-JIQqiWmLiEozOC0b0BtxZ/AOUtdUZHCBPgqIZ2kSJJqGwgb9neo44XdTHUC4HZSGqi03hOeB7W/E8rAlKnGe9g==",
+         "dev": true
+      },
       "strip-ansi": {
          "version": "4.0.0",
          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -4970,6 +6467,12 @@
          "requires": {
             "is-utf8": "^0.2.0"
          }
+      },
+      "strip-eof": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+         "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+         "dev": true
       },
       "strip-indent": {
          "version": "1.0.1",
@@ -5011,6 +6514,12 @@
          "version": "0.6.4",
          "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
          "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+         "dev": true
+      },
+      "text-extensions": {
+         "version": "1.9.0",
+         "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
+         "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
          "dev": true
       },
       "text-table": {
@@ -5147,6 +6656,12 @@
          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
          "dev": true
       },
+      "trim-off-newlines": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
+         "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+         "dev": true
+      },
       "trim-right": {
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -5211,6 +6726,12 @@
          "version": "4.0.8",
          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+         "dev": true
+      },
+      "typedarray": {
+         "version": "0.0.6",
+         "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+         "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
          "dev": true
       },
       "typescript": {
@@ -5430,11 +6951,64 @@
             "isexe": "^2.0.0"
          }
       },
+      "which-module": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+         "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+         "dev": true
+      },
       "wordwrap": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
          "dev": true
+      },
+      "wrap-ansi": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+         "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+         "dev": true,
+         "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+         },
+         "dependencies": {
+            "ansi-regex": {
+               "version": "2.1.1",
+               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+               "dev": true
+            },
+            "is-fullwidth-code-point": {
+               "version": "1.0.0",
+               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+               "dev": true,
+               "requires": {
+                  "number-is-nan": "^1.0.0"
+               }
+            },
+            "string-width": {
+               "version": "1.0.2",
+               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+               "dev": true,
+               "requires": {
+                  "code-point-at": "^1.0.0",
+                  "is-fullwidth-code-point": "^1.0.0",
+                  "strip-ansi": "^3.0.0"
+               }
+            },
+            "strip-ansi": {
+               "version": "3.0.1",
+               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+               "dev": true,
+               "requires": {
+                  "ansi-regex": "^2.0.0"
+               }
+            }
+         }
       },
       "wrappy": {
          "version": "1.0.2",
@@ -5456,6 +7030,101 @@
          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
          "dev": true
+      },
+      "y18n": {
+         "version": "4.0.0",
+         "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+         "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+         "dev": true
+      },
+      "yargs": {
+         "version": "12.0.5",
+         "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+         "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+         "dev": true,
+         "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+         },
+         "dependencies": {
+            "find-up": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+               "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+               "dev": true,
+               "requires": {
+                  "locate-path": "^3.0.0"
+               }
+            },
+            "locate-path": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+               "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+               "dev": true,
+               "requires": {
+                  "p-locate": "^3.0.0",
+                  "path-exists": "^3.0.0"
+               }
+            },
+            "p-limit": {
+               "version": "2.1.0",
+               "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+               "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+               "dev": true,
+               "requires": {
+                  "p-try": "^2.0.0"
+               }
+            },
+            "p-locate": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+               "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+               "dev": true,
+               "requires": {
+                  "p-limit": "^2.0.0"
+               }
+            },
+            "p-try": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+               "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+               "dev": true
+            },
+            "path-exists": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+               "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+               "dev": true
+            }
+         }
+      },
+      "yargs-parser": {
+         "version": "11.1.1",
+         "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+         "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+         "dev": true,
+         "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+         },
+         "dependencies": {
+            "camelcase": {
+               "version": "5.0.0",
+               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+               "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+               "dev": true
+            }
+         }
       },
       "yn": {
          "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,6 +128,750 @@
             "to-fast-properties": "^2.0.0"
          }
       },
+      "@commitlint/cli": {
+         "version": "7.5.2",
+         "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-7.5.2.tgz",
+         "integrity": "sha512-UQdW/wNb+XeANoYYLyuKEDIfWKSzdhJkPQZ8ie/IjfMNnsP+B23bkX4Ati+6U8zgz0yyngoxWl+3lfExiIL4hQ==",
+         "dev": true,
+         "requires": {
+            "@commitlint/format": "^7.5.0",
+            "@commitlint/lint": "^7.5.2",
+            "@commitlint/load": "^7.5.0",
+            "@commitlint/read": "^7.5.0",
+            "babel-polyfill": "6.26.0",
+            "chalk": "2.3.1",
+            "get-stdin": "5.0.1",
+            "lodash": "4.17.11",
+            "meow": "5.0.0",
+            "resolve-from": "4.0.0",
+            "resolve-global": "0.1.0"
+         },
+         "dependencies": {
+            "camelcase": {
+               "version": "4.1.0",
+               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+               "dev": true
+            },
+            "camelcase-keys": {
+               "version": "4.2.0",
+               "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+               "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+               "dev": true,
+               "requires": {
+                  "camelcase": "^4.1.0",
+                  "map-obj": "^2.0.0",
+                  "quick-lru": "^1.0.0"
+               }
+            },
+            "chalk": {
+               "version": "2.3.1",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+               "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^3.2.0",
+                  "escape-string-regexp": "^1.0.5",
+                  "supports-color": "^5.2.0"
+               }
+            },
+            "find-up": {
+               "version": "2.1.0",
+               "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+               "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+               "dev": true,
+               "requires": {
+                  "locate-path": "^2.0.0"
+               }
+            },
+            "get-stdin": {
+               "version": "5.0.1",
+               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+               "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+               "dev": true
+            },
+            "indent-string": {
+               "version": "3.2.0",
+               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+               "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+               "dev": true
+            },
+            "load-json-file": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+               "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+               "dev": true,
+               "requires": {
+                  "graceful-fs": "^4.1.2",
+                  "parse-json": "^4.0.0",
+                  "pify": "^3.0.0",
+                  "strip-bom": "^3.0.0"
+               }
+            },
+            "map-obj": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+               "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+               "dev": true
+            },
+            "meow": {
+               "version": "5.0.0",
+               "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+               "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+               "dev": true,
+               "requires": {
+                  "camelcase-keys": "^4.0.0",
+                  "decamelize-keys": "^1.0.0",
+                  "loud-rejection": "^1.0.0",
+                  "minimist-options": "^3.0.1",
+                  "normalize-package-data": "^2.3.4",
+                  "read-pkg-up": "^3.0.0",
+                  "redent": "^2.0.0",
+                  "trim-newlines": "^2.0.0",
+                  "yargs-parser": "^10.0.0"
+               }
+            },
+            "parse-json": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+               "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+               "dev": true,
+               "requires": {
+                  "error-ex": "^1.3.1",
+                  "json-parse-better-errors": "^1.0.1"
+               }
+            },
+            "path-type": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+               "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+               "dev": true,
+               "requires": {
+                  "pify": "^3.0.0"
+               }
+            },
+            "pify": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+               "dev": true
+            },
+            "read-pkg": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+               "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+               "dev": true,
+               "requires": {
+                  "load-json-file": "^4.0.0",
+                  "normalize-package-data": "^2.3.2",
+                  "path-type": "^3.0.0"
+               }
+            },
+            "read-pkg-up": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+               "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+               "dev": true,
+               "requires": {
+                  "find-up": "^2.0.0",
+                  "read-pkg": "^3.0.0"
+               }
+            },
+            "redent": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+               "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+               "dev": true,
+               "requires": {
+                  "indent-string": "^3.0.0",
+                  "strip-indent": "^2.0.0"
+               }
+            },
+            "strip-bom": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+               "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+               "dev": true
+            },
+            "strip-indent": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+               "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+               "dev": true
+            },
+            "trim-newlines": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+               "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+               "dev": true
+            },
+            "yargs-parser": {
+               "version": "10.1.0",
+               "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+               "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+               "dev": true,
+               "requires": {
+                  "camelcase": "^4.1.0"
+               }
+            }
+         }
+      },
+      "@commitlint/config-conventional": {
+         "version": "7.5.0",
+         "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-7.5.0.tgz",
+         "integrity": "sha512-odLgBfQ5xntFAmMfAmDY2C4EWhW+cSTbvbsRS7seb55DCa3IaxxSHHC9eXrR+hN/BdUT5vqAxdX1PkR996sq9Q==",
+         "dev": true
+      },
+      "@commitlint/ensure": {
+         "version": "7.5.2",
+         "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-7.5.2.tgz",
+         "integrity": "sha512-ZMJKHhSJC789chKy0kWp8EWbCpLPy6vKa+fopUVx+tWL7H8AeBbibXlqAnybg+HWNcb/RD7ORROx0IsgrK4IYA==",
+         "dev": true,
+         "requires": {
+            "lodash": "4.17.11"
+         }
+      },
+      "@commitlint/execute-rule": {
+         "version": "7.5.0",
+         "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-7.5.0.tgz",
+         "integrity": "sha512-K66aoly8mxSHmBA/Y8bKSPPcCAR4GpJEsvHaLDYOG7GsyChu8NgCD53L8GUqPW8lBCWwnmCiSL+RlOkNHJ0Gag==",
+         "dev": true,
+         "requires": {
+            "babel-runtime": "6.26.0"
+         }
+      },
+      "@commitlint/format": {
+         "version": "7.5.0",
+         "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-7.5.0.tgz",
+         "integrity": "sha512-DEeQXfTLUm9kARliCBfw3SlQRAYjK2aXeRAUMs1HPhLA2tjNFFGv6LOpFFNdiu/WV+o1ojcgIvBBjpHaVT+Tvw==",
+         "dev": true,
+         "requires": {
+            "babel-runtime": "^6.23.0",
+            "chalk": "^2.0.1"
+         }
+      },
+      "@commitlint/is-ignored": {
+         "version": "7.5.1",
+         "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-7.5.1.tgz",
+         "integrity": "sha512-8JZCgy6bWSnjOT5cTTiyEAGp+Y4+5CUknhVbyiPxTRbjy6yF0aMKs1gMTfHrNHTKsasgmkCyPQd4C2eOPceuKA==",
+         "dev": true,
+         "requires": {
+            "semver": "5.6.0"
+         },
+         "dependencies": {
+            "semver": {
+               "version": "5.6.0",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+               "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+               "dev": true
+            }
+         }
+      },
+      "@commitlint/lint": {
+         "version": "7.5.2",
+         "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-7.5.2.tgz",
+         "integrity": "sha512-DY/UfGFDquMno+5c6+tE50rMxpjdQK3CRG+nktgYlVz1UAqeUD+bRc3pvX5HwAsuGvyDrWAjtszHtEDeYJKcjw==",
+         "dev": true,
+         "requires": {
+            "@commitlint/is-ignored": "^7.5.1",
+            "@commitlint/parse": "^7.5.0",
+            "@commitlint/rules": "^7.5.2",
+            "babel-runtime": "^6.23.0",
+            "lodash": "4.17.11"
+         }
+      },
+      "@commitlint/load": {
+         "version": "7.5.0",
+         "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.5.0.tgz",
+         "integrity": "sha512-fhBER/rzPsteM6zq5qqMiOi+A2bHKCE/0PKmOzYgaqTKcG9c1SsOle9phPemW85to8Gxd2YgUOVLsZkCMltLtA==",
+         "dev": true,
+         "requires": {
+            "@commitlint/execute-rule": "^7.5.0",
+            "@commitlint/resolve-extends": "^7.5.0",
+            "babel-runtime": "^6.23.0",
+            "cosmiconfig": "^4.0.0",
+            "lodash": "4.17.11",
+            "resolve-from": "^4.0.0"
+         }
+      },
+      "@commitlint/message": {
+         "version": "7.5.0",
+         "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-7.5.0.tgz",
+         "integrity": "sha512-5YOhsqy/MgHH7vyDsmmzO6Jr3ygr1pXbCm9NR3XB51wjg55Kd6/6dVlkhS/FmDp99pfwTdHb0TyeDFEjP98waw==",
+         "dev": true
+      },
+      "@commitlint/parse": {
+         "version": "7.5.0",
+         "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-7.5.0.tgz",
+         "integrity": "sha512-hWASM8SBFTBtlFkKrEtD1qW6yTe2BsfoRiMKuYyRCTd+739TUF17og5vgQVuWttbGP0gXaciW44NygS2YjZmfA==",
+         "dev": true,
+         "requires": {
+            "conventional-changelog-angular": "^1.3.3",
+            "conventional-commits-parser": "^2.1.0",
+            "lodash": "^4.17.11"
+         },
+         "dependencies": {
+            "camelcase": {
+               "version": "4.1.0",
+               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+               "dev": true
+            },
+            "camelcase-keys": {
+               "version": "4.2.0",
+               "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+               "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+               "dev": true,
+               "requires": {
+                  "camelcase": "^4.1.0",
+                  "map-obj": "^2.0.0",
+                  "quick-lru": "^1.0.0"
+               }
+            },
+            "conventional-changelog-angular": {
+               "version": "1.6.6",
+               "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
+               "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
+               "dev": true,
+               "requires": {
+                  "compare-func": "^1.3.1",
+                  "q": "^1.5.1"
+               }
+            },
+            "conventional-commits-parser": {
+               "version": "2.1.7",
+               "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
+               "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
+               "dev": true,
+               "requires": {
+                  "JSONStream": "^1.0.4",
+                  "is-text-path": "^1.0.0",
+                  "lodash": "^4.2.1",
+                  "meow": "^4.0.0",
+                  "split2": "^2.0.0",
+                  "through2": "^2.0.0",
+                  "trim-off-newlines": "^1.0.0"
+               }
+            },
+            "find-up": {
+               "version": "2.1.0",
+               "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+               "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+               "dev": true,
+               "requires": {
+                  "locate-path": "^2.0.0"
+               }
+            },
+            "indent-string": {
+               "version": "3.2.0",
+               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+               "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+               "dev": true
+            },
+            "load-json-file": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+               "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+               "dev": true,
+               "requires": {
+                  "graceful-fs": "^4.1.2",
+                  "parse-json": "^4.0.0",
+                  "pify": "^3.0.0",
+                  "strip-bom": "^3.0.0"
+               }
+            },
+            "map-obj": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+               "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+               "dev": true
+            },
+            "meow": {
+               "version": "4.0.1",
+               "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+               "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+               "dev": true,
+               "requires": {
+                  "camelcase-keys": "^4.0.0",
+                  "decamelize-keys": "^1.0.0",
+                  "loud-rejection": "^1.0.0",
+                  "minimist": "^1.1.3",
+                  "minimist-options": "^3.0.1",
+                  "normalize-package-data": "^2.3.4",
+                  "read-pkg-up": "^3.0.0",
+                  "redent": "^2.0.0",
+                  "trim-newlines": "^2.0.0"
+               }
+            },
+            "parse-json": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+               "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+               "dev": true,
+               "requires": {
+                  "error-ex": "^1.3.1",
+                  "json-parse-better-errors": "^1.0.1"
+               }
+            },
+            "path-type": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+               "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+               "dev": true,
+               "requires": {
+                  "pify": "^3.0.0"
+               }
+            },
+            "pify": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+               "dev": true
+            },
+            "read-pkg": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+               "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+               "dev": true,
+               "requires": {
+                  "load-json-file": "^4.0.0",
+                  "normalize-package-data": "^2.3.2",
+                  "path-type": "^3.0.0"
+               }
+            },
+            "read-pkg-up": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+               "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+               "dev": true,
+               "requires": {
+                  "find-up": "^2.0.0",
+                  "read-pkg": "^3.0.0"
+               }
+            },
+            "redent": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+               "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+               "dev": true,
+               "requires": {
+                  "indent-string": "^3.0.0",
+                  "strip-indent": "^2.0.0"
+               }
+            },
+            "split2": {
+               "version": "2.2.0",
+               "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+               "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+               "dev": true,
+               "requires": {
+                  "through2": "^2.0.2"
+               }
+            },
+            "strip-bom": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+               "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+               "dev": true
+            },
+            "strip-indent": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+               "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+               "dev": true
+            },
+            "trim-newlines": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+               "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+               "dev": true
+            }
+         }
+      },
+      "@commitlint/read": {
+         "version": "7.5.0",
+         "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-7.5.0.tgz",
+         "integrity": "sha512-uqGFCKZGnBUCTkxoCCJp4MfWUkegXkyT0T0RVM9diyG6uNWPWlMH1509sjLFlyeJKG+cSyYGG/d6T103ScMb4Q==",
+         "dev": true,
+         "requires": {
+            "@commitlint/top-level": "^7.5.0",
+            "@marionebl/sander": "^0.6.0",
+            "babel-runtime": "^6.23.0",
+            "git-raw-commits": "^1.3.0"
+         },
+         "dependencies": {
+            "camelcase": {
+               "version": "4.1.0",
+               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+               "dev": true
+            },
+            "camelcase-keys": {
+               "version": "4.2.0",
+               "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+               "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+               "dev": true,
+               "requires": {
+                  "camelcase": "^4.1.0",
+                  "map-obj": "^2.0.0",
+                  "quick-lru": "^1.0.0"
+               }
+            },
+            "find-up": {
+               "version": "2.1.0",
+               "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+               "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+               "dev": true,
+               "requires": {
+                  "locate-path": "^2.0.0"
+               }
+            },
+            "git-raw-commits": {
+               "version": "1.3.6",
+               "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
+               "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
+               "dev": true,
+               "requires": {
+                  "dargs": "^4.0.1",
+                  "lodash.template": "^4.0.2",
+                  "meow": "^4.0.0",
+                  "split2": "^2.0.0",
+                  "through2": "^2.0.0"
+               }
+            },
+            "indent-string": {
+               "version": "3.2.0",
+               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+               "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+               "dev": true
+            },
+            "load-json-file": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+               "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+               "dev": true,
+               "requires": {
+                  "graceful-fs": "^4.1.2",
+                  "parse-json": "^4.0.0",
+                  "pify": "^3.0.0",
+                  "strip-bom": "^3.0.0"
+               }
+            },
+            "map-obj": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+               "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+               "dev": true
+            },
+            "meow": {
+               "version": "4.0.1",
+               "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+               "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+               "dev": true,
+               "requires": {
+                  "camelcase-keys": "^4.0.0",
+                  "decamelize-keys": "^1.0.0",
+                  "loud-rejection": "^1.0.0",
+                  "minimist": "^1.1.3",
+                  "minimist-options": "^3.0.1",
+                  "normalize-package-data": "^2.3.4",
+                  "read-pkg-up": "^3.0.0",
+                  "redent": "^2.0.0",
+                  "trim-newlines": "^2.0.0"
+               }
+            },
+            "parse-json": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+               "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+               "dev": true,
+               "requires": {
+                  "error-ex": "^1.3.1",
+                  "json-parse-better-errors": "^1.0.1"
+               }
+            },
+            "path-type": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+               "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+               "dev": true,
+               "requires": {
+                  "pify": "^3.0.0"
+               }
+            },
+            "pify": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+               "dev": true
+            },
+            "read-pkg": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+               "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+               "dev": true,
+               "requires": {
+                  "load-json-file": "^4.0.0",
+                  "normalize-package-data": "^2.3.2",
+                  "path-type": "^3.0.0"
+               }
+            },
+            "read-pkg-up": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+               "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+               "dev": true,
+               "requires": {
+                  "find-up": "^2.0.0",
+                  "read-pkg": "^3.0.0"
+               }
+            },
+            "redent": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+               "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+               "dev": true,
+               "requires": {
+                  "indent-string": "^3.0.0",
+                  "strip-indent": "^2.0.0"
+               }
+            },
+            "split2": {
+               "version": "2.2.0",
+               "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+               "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+               "dev": true,
+               "requires": {
+                  "through2": "^2.0.2"
+               }
+            },
+            "strip-bom": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+               "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+               "dev": true
+            },
+            "strip-indent": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+               "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+               "dev": true
+            },
+            "trim-newlines": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+               "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+               "dev": true
+            }
+         }
+      },
+      "@commitlint/resolve-extends": {
+         "version": "7.5.0",
+         "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-7.5.0.tgz",
+         "integrity": "sha512-FRIyPuqGvGa03OT4VgOHakizcw8YR5rdm77JsZff1rSnpxk6i+025I6qMeHqCIr5FaVIA0kR3FlC+MJFUs165A==",
+         "dev": true,
+         "requires": {
+            "babel-runtime": "6.26.0",
+            "import-fresh": "^3.0.0",
+            "lodash": "4.17.11",
+            "resolve-from": "^4.0.0",
+            "resolve-global": "^0.1.0"
+         }
+      },
+      "@commitlint/rules": {
+         "version": "7.5.2",
+         "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-7.5.2.tgz",
+         "integrity": "sha512-eDN1UFPcBOjdnlI3syuo7y99SjGH/dUV6S9NvBocAye8ln5dfKiI2shhWochJhl36r/kYWU8Wrvl2NZJL3c52g==",
+         "dev": true,
+         "requires": {
+            "@commitlint/ensure": "^7.5.2",
+            "@commitlint/message": "^7.5.0",
+            "@commitlint/to-lines": "^7.5.0",
+            "babel-runtime": "^6.23.0"
+         }
+      },
+      "@commitlint/to-lines": {
+         "version": "7.5.0",
+         "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-7.5.0.tgz",
+         "integrity": "sha512-ZQ3LxPNuQ/J7q42hkiPWN5fUIjWae85H2HHoBB+/Rw1fo+oehvr4Xyt+Oa9Mx5WbBnev/wXnUFjXgoadv1RZ5A==",
+         "dev": true
+      },
+      "@commitlint/top-level": {
+         "version": "7.5.0",
+         "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-7.5.0.tgz",
+         "integrity": "sha512-oTu185GufTYHjTXPHu6k6HL7iuASOvDOtQizZWRSxj0VXuoki6e0HzvGZsRsycDTOn04Q9hVu+PhF83IUwRpeg==",
+         "dev": true,
+         "requires": {
+            "find-up": "^2.1.0"
+         },
+         "dependencies": {
+            "find-up": {
+               "version": "2.1.0",
+               "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+               "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+               "dev": true,
+               "requires": {
+                  "locate-path": "^2.0.0"
+               }
+            }
+         }
+      },
+      "@commitlint/travis-cli": {
+         "version": "7.5.2",
+         "resolved": "https://registry.npmjs.org/@commitlint/travis-cli/-/travis-cli-7.5.2.tgz",
+         "integrity": "sha512-kbkn8TIjRtGWcKOJBM/fbT9yRPjbLTybetRH5mkAQdX9ratkV9+N3akaOSmv5eemNfHsOM1cdrWkcjZbSqZV2A==",
+         "dev": true,
+         "requires": {
+            "@commitlint/cli": "^7.5.2",
+            "babel-runtime": "6.26.0",
+            "execa": "0.9.0"
+         },
+         "dependencies": {
+            "cross-spawn": {
+               "version": "5.1.0",
+               "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+               "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+               "dev": true,
+               "requires": {
+                  "lru-cache": "^4.0.1",
+                  "shebang-command": "^1.2.0",
+                  "which": "^1.2.9"
+               }
+            },
+            "execa": {
+               "version": "0.9.0",
+               "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
+               "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
+               "dev": true,
+               "requires": {
+                  "cross-spawn": "^5.0.1",
+                  "get-stream": "^3.0.0",
+                  "is-stream": "^1.1.0",
+                  "npm-run-path": "^2.0.0",
+                  "p-finally": "^1.0.0",
+                  "signal-exit": "^3.0.0",
+                  "strip-eof": "^1.0.0"
+               }
+            },
+            "get-stream": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+               "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+               "dev": true
+            }
+         }
+      },
+      "@marionebl/sander": {
+         "version": "0.6.1",
+         "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",
+         "integrity": "sha1-GViWWHTyS8Ub5Ih1/rUNZC/EH3s=",
+         "dev": true,
+         "requires": {
+            "graceful-fs": "^4.1.3",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.2"
+         }
+      },
       "@silvermine/chai-strictly-equal": {
          "version": "1.1.0",
          "resolved": "https://registry.npmjs.org/@silvermine/chai-strictly-equal/-/chai-strictly-equal-1.1.0.tgz",
@@ -487,6 +1231,35 @@
          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
          "dev": true
+      },
+      "babel-polyfill": {
+         "version": "6.26.0",
+         "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+         "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+         "dev": true,
+         "requires": {
+            "babel-runtime": "^6.26.0",
+            "core-js": "^2.5.0",
+            "regenerator-runtime": "^0.10.5"
+         },
+         "dependencies": {
+            "regenerator-runtime": {
+               "version": "0.10.5",
+               "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+               "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+               "dev": true
+            }
+         }
+      },
+      "babel-runtime": {
+         "version": "6.26.0",
+         "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+         "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+         "dev": true,
+         "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
+         }
       },
       "balanced-match": {
          "version": "1.0.0",
@@ -1594,11 +2367,57 @@
          "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
          "dev": true
       },
+      "core-js": {
+         "version": "2.6.5",
+         "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+         "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+         "dev": true
+      },
       "core-util-is": {
          "version": "1.0.2",
          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
          "dev": true
+      },
+      "cosmiconfig": {
+         "version": "4.0.0",
+         "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+         "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+         "dev": true,
+         "requires": {
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.9.0",
+            "parse-json": "^4.0.0",
+            "require-from-string": "^2.0.1"
+         },
+         "dependencies": {
+            "esprima": {
+               "version": "4.0.1",
+               "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+               "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+               "dev": true
+            },
+            "js-yaml": {
+               "version": "3.12.1",
+               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+               "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+               "dev": true,
+               "requires": {
+                  "argparse": "^1.0.7",
+                  "esprima": "^4.0.0"
+               }
+            },
+            "parse-json": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+               "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+               "dev": true,
+               "requires": {
+                  "error-ex": "^1.3.1",
+                  "json-parse-better-errors": "^1.0.1"
+               }
+            }
+         }
       },
       "coveralls": {
          "version": "3.0.2",
@@ -2883,6 +3702,15 @@
             "path-is-absolute": "^1.0.0"
          }
       },
+      "global-dirs": {
+         "version": "0.1.1",
+         "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+         "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+         "dev": true,
+         "requires": {
+            "ini": "^1.3.4"
+         }
+      },
       "global-modules": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
@@ -3460,6 +4288,12 @@
             }
          }
       },
+      "is-directory": {
+         "version": "0.3.1",
+         "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+         "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+         "dev": true
+      },
       "is-extendable": {
          "version": "0.1.1",
          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -3906,6 +4740,16 @@
          "requires": {
             "currently-unhandled": "^0.4.1",
             "signal-exit": "^3.0.0"
+         }
+      },
+      "lru-cache": {
+         "version": "4.1.5",
+         "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+         "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+         "dev": true,
+         "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
          }
       },
       "make-error": {
@@ -5756,6 +6600,12 @@
          "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
          "dev": true
       },
+      "pseudomap": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+         "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+         "dev": true
+      },
       "psl": {
          "version": "1.1.31",
          "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
@@ -5879,6 +6729,12 @@
             "strip-indent": "^1.0.1"
          }
       },
+      "regenerator-runtime": {
+         "version": "0.11.1",
+         "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+         "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+         "dev": true
+      },
       "regex-not": {
          "version": "1.0.2",
          "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -5958,6 +6814,12 @@
          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
          "dev": true
       },
+      "require-from-string": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+         "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+         "dev": true
+      },
       "require-main-filename": {
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
@@ -5991,6 +6853,15 @@
          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
          "dev": true
+      },
+      "resolve-global": {
+         "version": "0.1.0",
+         "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-0.1.0.tgz",
+         "integrity": "sha1-j7As/Vt9sgEY6IYxHxWvlb0V+9k=",
+         "dev": true,
+         "requires": {
+            "global-dirs": "^0.1.0"
+         }
       },
       "resolve-url": {
          "version": "0.2.1",
@@ -7078,6 +7949,12 @@
          "version": "4.0.0",
          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+         "dev": true
+      },
+      "yallist": {
+         "version": "2.1.2",
+         "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+         "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
          "dev": true
       },
       "yargs": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
       "@types/underscore": "1.8.9",
       "chai": "4.2.0",
       "coveralls": "3.0.2",
+      "cz-conventional-changelog": "2.1.0",
       "grunt": "1.0.3",
       "grunt-cli": "1.3.1",
       "grunt-concurrent": "2.3.1",
@@ -57,5 +58,10 @@
       "qs": "6.6.0",
       "tslib": "1.9.3",
       "underscore": "1.9.1"
+   },
+   "config": {
+      "commitizen": {
+         "path": "./node_modules/cz-conventional-changelog"
+      }
    }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
       "nyc": "13.1.0",
       "sinon": "5.1.1",
       "source-map-support": "0.5.9",
+      "standard-version": "git+https://github.com/jthomerson/standard-version.git#fix-305-header-repeat",
       "ts-node": "7.0.1",
       "typescript": "3.2.2"
    },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
       "npm": "6.4.1"
    },
    "devDependencies": {
+      "@commitlint/cli": "7.5.2",
+      "@commitlint/config-conventional": "7.5.0",
+      "@commitlint/travis-cli": "7.5.2",
       "@silvermine/chai-strictly-equal": "1.1.0",
       "@silvermine/eslint-config": "2.0.0",
       "@silvermine/typescript-config": "0.9.0",


### PR DESCRIPTION
Add:

 * linting for commit messages (e.g. `commitlint --from=origin/master`)
   * automatically linted in our Travis CI builds
 * changelog generation
 * automatic version bumping based on commit messages (`standard-version`)

We are using the default configuration for commit messages. See [Angular's commit guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) for details on the syntax. This format is also called [conventional changelog](https://github.com/conventional-changelog/conventional-changelog).

After we gain some experience with this format, we'll determine if we're keeping it, or tweaking it to our needs. Whenever we make that call, we'll also update our [commit history standards](https://github.com/silvermine/silvermine-info/blob/master/commit-history.md) to reflect these changes (although most of the content in that document will still apply).