### PR TITLE
fix: case-sensitive routing for sub-router mounting points (#17)

### DIFF
--- a/src/Router.ts
+++ b/src/Router.ts
@@ -70,14 +70,7 @@ export default class Router implements IRouter {
     * code hinting / auto-completion.
     */
    public addSubRouter(path: PathParams, router: Router): this {
-      // Note: this overriding of the case sensitivity of the passed-in router is likely
-      // ineffective for most usecases because the user probably created their router and
-      // added a bunch of routes to it before adding that router to this one. When the
-      // routes are created (technically the `IRequestMatchingProcessorChain` objects, in
-      // particular `RouteMatchingProcessorChain`), the case sensitivity is already set
-      // (inherited from the router that created the chain).
-      router.routerOptions.caseSensitive = this.routerOptions.caseSensitive;
-      this._processors.push(new SubRouterProcessorChain(path, router));
+      this._processors.push(new SubRouterProcessorChain(path, router, this.routerOptions));
       return this;
    }
 

--- a/tests/chains/SubRouterProcessorChain.test.ts
+++ b/tests/chains/SubRouterProcessorChain.test.ts
@@ -29,7 +29,7 @@ describe('SubRouterProcessorChain', () => {
          let app = new Application(),
              req = new Request(app, _.extend(apiGatewayRequest(), { path: path }), handlerContext()),
              router = new TestRouter(spy()),
-             chain = new SubRouterProcessorChain(routes, router);
+             chain = new SubRouterProcessorChain(routes, router, app.routerOptions);
 
          expect(chain.matches(req)).to.eql(expectation);
       };
@@ -58,7 +58,7 @@ describe('SubRouterProcessorChain', () => {
              done = spy(),
              handle = spy(),
              router = new TestRouter(handle),
-             chain = new SubRouterProcessorChain(routes, router);
+             chain = new SubRouterProcessorChain(routes, router, app.routerOptions);
 
          chain.run('nothing', req, resp, done);
          assert.calledOnce(handle);


### PR DESCRIPTION
When a sub-router was mounted to a given path, the
SubRouterProcessorChain did not respect the router's case-sensitivity
settings. Additionally, sub-routers should NOT inherit their
case-sensitivity settings from their parent router.