### PR TITLE
feat: Add 'prepare' script to build dist on 'npm install' from git repo (#41)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
    "types": "./dist/types/index.d.ts",
    "module": "./dist/esm/index",
    "scripts": {
+      "prepare": "grunt build",
       "test": "TS_NODE_PROJECT='tests/tsconfig.json' TS_NODE_FILES=true nyc mocha --opts ./.mocha.opts"
    },
    "author": "Jeremy Thomerson",


### PR DESCRIPTION
With lambda-express in early development, features and fixes are getting added and need to
be tested faster than new versions are being cut. As such, it would be handy to be able to
install lambda-express directly from the git repo. However, due to the build process and
needing the dist files, this isn't currently possible using `npm i <repo>`. Fortunately, a
`prepare` script was added in npm 5. This script is ran when installing from a git repo
and can be used to build the needed dist files.

More info: https://blog.jim-nielsen.com/2018/installing-and-building-an-npm-package-from-github/#installing-and-building-packages-with-npm-from-github