### PR TITLE
Add a safeguard for JS users when setting response headers

### DIFF
--- a/src/Response.ts
+++ b/src/Response.ts
@@ -54,6 +54,12 @@ export default class Response {
          this._headers[arg0] = [ arg1 ];
       } else if (isStringMap(arg0)) {
          _.each(arg0, (v, k) => { this.set(k, v); });
+      } else {
+         // This is here to help JS users who may not benefit from the type safety. If
+         // they were to do something like `resp.set('X-Foo', true)`, it would silently
+         // fail. Loudly failing seems better because at least they know - and we didn't
+         // have to guess at what their intent was.
+         this._request.log.error(`Header value for "${arg0}" must be a string.`);
       }
       return this;
    }

--- a/src/logging/logging-types.ts
+++ b/src/logging/logging-types.ts
@@ -19,7 +19,7 @@ export interface ILogger {
     * @param data Custom data to add to the log message. Added to the log object under the
     * `data` key.
     */
-   trace(msg: string, data: unknown): void;
+   trace(msg: string, data?: unknown): void;
 
    /**
     * Log a message at the `debug` log level. The logger will only log a message for this
@@ -29,7 +29,7 @@ export interface ILogger {
     * @param data Custom data to add to the log message. Added to the log object under the
     * `data` key.
     */
-   debug(msg: string, data: unknown): void;
+   debug(msg: string, data?: unknown): void;
 
    /**
     * Log a message at the `info` log level. The logger will only log a message for this
@@ -39,7 +39,7 @@ export interface ILogger {
     * @param data Custom data to add to the log message. Added to the log object under the
     * `data` key.
     */
-   info(msg: string, data: unknown): void;
+   info(msg: string, data?: unknown): void;
 
    /**
     * Log a message at the `warn` log level. The logger will only log a message for this
@@ -49,7 +49,7 @@ export interface ILogger {
     * @param data Custom data to add to the log message. Added to the log object under the
     * `data` key.
     */
-   warn(msg: string, data: unknown): void;
+   warn(msg: string, data?: unknown): void;
 
    /**
     * Log a message at the `error` log level. The logger will only log a message for this
@@ -59,7 +59,7 @@ export interface ILogger {
     * @param data Custom data to add to the log message. Added to the log object under the
     * `data` key.
     */
-   error(msg: string, data: unknown): void;
+   error(msg: string, data?: unknown): void;
 
    /**
     * Log a message at the `fatal` log level. The logger will always log a message unless
@@ -69,7 +69,7 @@ export interface ILogger {
     * @param data Custom data to add to the log message. Added to the log object under the
     * `data` key.
     */
-   fatal(msg: string, data: unknown): void;
+   fatal(msg: string, data?: unknown): void;
 
    /**
     * Gets the current logging level.


### PR DESCRIPTION
We aren't adding many JS safeguards since we're providing type safety by
means of TypeScript. However, in this case, many users could easily have
been thrown off by trying to set response headers with non-string values
(e.g. booleans and numbers). Rather than a) failing silently, or b)
trying to convert those values for them, guessing at how they want them
converted, we will instead log an error to warn the developer of the
mistake.