### PR TITLE
feat: expose Response.body as read-only property

### DIFF
--- a/src/Response.ts
+++ b/src/Response.ts
@@ -28,6 +28,15 @@ export default class Response {
       this._lambdaCallback = cb;
    }
 
+   /**
+    * Expose the body of the response as a read-only property so that it can be used in
+    * places such as after write listeners (for validating or logging the body that was
+    * sent).
+    */
+   public get body(): string {
+      return this._body;
+   }
+
    // METHODS RELATED TO SETTING RESPONSE HEADERS AND CODES THAT DO NOT SEND RESPONSES
 
    /**

--- a/tests/Response.test.ts
+++ b/tests/Response.test.ts
@@ -589,6 +589,15 @@ describe('Response', () => {
       });
    });
 
+   describe('body property', () => {
+      it('contains what was sent in the response', () => {
+         const resp = new Response(app, new Request(app, apiGatewayRequest(), handlerContext()), spy());
+
+         resp.send({ foo: 'bar' });
+         expect(resp.body).to.eql(JSON.stringify({ foo: 'bar' }));
+      });
+   });
+
    describe('response sending functions', () => {
       let cb: SinonSpy, resp: Response;
 


### PR DESCRIPTION
Anything that runs after a response is sent may need to access the body
that was sent. This might be for logging or auditing purposes. Thus, the
response body needs to be accessible to the user.