### PR TITLE
feat: Export types used in the public interface (#22)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,37 @@ export {
    Response,
    Router,
 };
+
+// We need to export only types that are used in public interfaces (e.g. those used in
+// concrete classes like Application, Request, Response, Router, exported above).
+export {
+   IRoute,
+   IRouter,
+   PathParams,
+   NextCallback,
+   RouterOptions,
+   RequestProcessor,
+   AnyRequestProcessor,
+   ProcessorOrProcessors,
+   ErrorHandlingRequestProcessor,
+} from './interfaces';
+
+export {
+   CookieOpts,
+   RequestEvent,
+   HandlerContext,
+   LambdaEventSourceType,
+   RequestEventRequestContext,
+} from './request-response-types';
+
+export {
+   StringMap,
+   StringUnknownMap,
+   KeyValueStringObject,
+   StringArrayOfStringsMap,
+} from '@silvermine/toolbox';
+
+export {
+   ILogger,
+   LogLevel,
+} from './logging/logging-types';


### PR DESCRIPTION
Any type (class, interface, literal type, etc) that's used by Lambda
Express' public API as a method return type, parameter type, or property
type must be exported on `src/index.ts` so that it's available to be
used in client code.