### PR TITLE
feat: Export types that are useful for tests (#22)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,8 +28,13 @@ export {
    CookieOpts,
    RequestEvent,
    HandlerContext,
+   ResponseResult,
    LambdaEventSourceType,
+   APIGatewayRequestEvent,
    RequestEventRequestContext,
+   APIGatewayEventRequestContext,
+   ApplicationLoadBalancerRequestEvent,
+   ApplicationLoadBalancerEventRequestContext,
 } from './request-response-types';
 
 export {


### PR DESCRIPTION
There are some types that are not very likely to be used as part of the
public API, but that are useful to have when creating mock API Gateway /
ALB events for testing. These are now exported.