### PR TITLE
chore: upgrade @silvermine/standardization and related standards config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install: npm i -g npm@6.14.12
 script:
    - node --version
    - npm --version
-   - grunt standards
+   - npm run standards
    - commitlint-travis
    - grunt clean build
    - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-   - "node" # Latest node version
+   # TODO: Re-enable when Travis fixes their images issues with latest Node.js
+   # See: https://github.com/silvermine/standardization/issues/39
+   # - "node" # Latest node version
    - "lts/*" # Latest LTS version
    - "14"
    - "12"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,7 +20,6 @@ module.exports = (grunt) => {
             './tests/**/*.ts',
          ],
          configs: {
-            standards: 'tsconfig.json',
             commonjs: 'src/tsconfig.commonjs.json',
             esm: 'src/tsconfig.esm.json',
             types: 'src/tsconfig.types.json',
@@ -47,9 +46,6 @@ module.exports = (grunt) => {
          options: {
             failOnError: true,
          },
-         standards: {
-            cmd: `${config.commands.tsc} -p ${config.ts.configs.standards} --pretty`,
-         },
          types: {
             cmd: `${config.commands.tsc} -p ${config.ts.configs.types} --pretty`,
          },
@@ -68,15 +64,6 @@ module.exports = (grunt) => {
 
       concurrent: {
          'build-ts-outputs': [ 'build-types', 'build-esm', 'build-commonjs' ],
-      },
-
-      markdownlint: {
-         all: {
-            src: [ './README.md' ],
-            options: {
-               config: grunt.file.readJSON('.markdownlint.json'),
-            },
-         },
       },
 
       watch: {
@@ -99,17 +86,13 @@ module.exports = (grunt) => {
    grunt.loadNpmTasks('grunt-contrib-clean');
    grunt.loadNpmTasks('grunt-concurrent');
    grunt.loadNpmTasks('grunt-contrib-watch');
-   grunt.loadNpmTasks('grunt-markdownlint');
-
-   grunt.registerTask('standards', [ 'eslint', 'exec:standards' ]);
-   grunt.registerTask('default', [ 'standards' ]);
 
    grunt.registerTask('build-types', 'exec:types');
    grunt.registerTask('build-esm', 'exec:esm');
    grunt.registerTask('build-commonjs', 'exec:commonjs');
    grunt.registerTask('build-ts-outputs', 'concurrent:build-ts-outputs');
    grunt.registerTask('build', [ 'concurrent:build-ts-outputs' ]);
-
    grunt.registerTask('develop', [ 'clean', 'build', 'watch' ]);
 
+   grunt.registerTask('default', [ 'build' ]);
 };

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ familiar will accelerate your development, allowing you to focus on your busines
 
 ## Usage
 
-Here's a simple example to get you up and running quickly (assumes your execution environment is Node 12.x):
+Here's a simple example to get you up and running quickly (assumes your execution environment
+is Node 12.x):
 
 `npm i @silvermine/lambda-express`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,13 @@
    "requires": true,
    "dependencies": {
       "@ampproject/remapping": {
-         "version": "2.1.2",
-         "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-         "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+         "version": "2.2.0",
+         "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+         "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
          "dev": true,
          "requires": {
-            "@jridgewell/trace-mapping": "^0.3.0"
+            "@jridgewell/gen-mapping": "^0.1.0",
+            "@jridgewell/trace-mapping": "^0.3.9"
          }
       },
       "@babel/code-frame": {
@@ -23,31 +24,31 @@
          }
       },
       "@babel/compat-data": {
-         "version": "7.17.7",
-         "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.7.tgz",
-         "integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==",
+         "version": "7.17.10",
+         "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.10.tgz",
+         "integrity": "sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw==",
          "dev": true
       },
       "@babel/core": {
-         "version": "7.17.8",
-         "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
-         "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
+         "version": "7.17.10",
+         "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.10.tgz",
+         "integrity": "sha512-liKoppandF3ZcBnIYFjfSDHZLKdLHGJRkoWtG8zQyGJBQfIYobpnVGI5+pLBNtS6psFLDzyq8+h5HiVljW9PNA==",
          "dev": true,
          "requires": {
             "@ampproject/remapping": "^2.1.0",
             "@babel/code-frame": "^7.16.7",
-            "@babel/generator": "^7.17.7",
-            "@babel/helper-compilation-targets": "^7.17.7",
+            "@babel/generator": "^7.17.10",
+            "@babel/helper-compilation-targets": "^7.17.10",
             "@babel/helper-module-transforms": "^7.17.7",
-            "@babel/helpers": "^7.17.8",
-            "@babel/parser": "^7.17.8",
+            "@babel/helpers": "^7.17.9",
+            "@babel/parser": "^7.17.10",
             "@babel/template": "^7.16.7",
-            "@babel/traverse": "^7.17.3",
-            "@babel/types": "^7.17.0",
+            "@babel/traverse": "^7.17.10",
+            "@babel/types": "^7.17.10",
             "convert-source-map": "^1.7.0",
             "debug": "^4.1.0",
             "gensync": "^1.0.0-beta.2",
-            "json5": "^2.1.2",
+            "json5": "^2.2.1",
             "semver": "^6.3.0"
          },
          "dependencies": {
@@ -61,34 +62,24 @@
                }
             },
             "@babel/generator": {
-               "version": "7.17.7",
-               "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
-               "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+               "version": "7.17.10",
+               "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.10.tgz",
+               "integrity": "sha512-46MJZZo9y3o4kmhBVc7zW7i8dtR1oIK/sdO5NcfcZRhTGYi+KKJRtHNgsU6c4VUcJmUNV/LQdebD/9Dlv4K+Tg==",
                "dev": true,
                "requires": {
-                  "@babel/types": "^7.17.0",
-                  "jsesc": "^2.5.1",
-                  "source-map": "^0.5.0"
+                  "@babel/types": "^7.17.10",
+                  "@jridgewell/gen-mapping": "^0.1.0",
+                  "jsesc": "^2.5.1"
                }
             },
             "@babel/helper-function-name": {
-               "version": "7.16.7",
-               "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
-               "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+               "version": "7.17.9",
+               "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
+               "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
                "dev": true,
                "requires": {
-                  "@babel/helper-get-function-arity": "^7.16.7",
                   "@babel/template": "^7.16.7",
-                  "@babel/types": "^7.16.7"
-               }
-            },
-            "@babel/helper-get-function-arity": {
-               "version": "7.16.7",
-               "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
-               "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
-               "dev": true,
-               "requires": {
-                  "@babel/types": "^7.16.7"
+                  "@babel/types": "^7.17.0"
                }
             },
             "@babel/helper-split-export-declaration": {
@@ -101,9 +92,9 @@
                }
             },
             "@babel/highlight": {
-               "version": "7.16.10",
-               "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-               "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+               "version": "7.17.9",
+               "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+               "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
                "dev": true,
                "requires": {
                   "@babel/helper-validator-identifier": "^7.16.7",
@@ -112,9 +103,9 @@
                }
             },
             "@babel/parser": {
-               "version": "7.17.8",
-               "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
-               "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
+               "version": "7.17.10",
+               "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.10.tgz",
+               "integrity": "sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==",
                "dev": true
             },
             "@babel/template": {
@@ -129,27 +120,27 @@
                }
             },
             "@babel/traverse": {
-               "version": "7.17.3",
-               "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
-               "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+               "version": "7.17.10",
+               "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.10.tgz",
+               "integrity": "sha512-VmbrTHQteIdUUQNTb+zE12SHS/xQVIShmBPhlNP12hD5poF2pbITW1Z4172d03HegaQWhLffdkRJYtAzp0AGcw==",
                "dev": true,
                "requires": {
                   "@babel/code-frame": "^7.16.7",
-                  "@babel/generator": "^7.17.3",
+                  "@babel/generator": "^7.17.10",
                   "@babel/helper-environment-visitor": "^7.16.7",
-                  "@babel/helper-function-name": "^7.16.7",
+                  "@babel/helper-function-name": "^7.17.9",
                   "@babel/helper-hoist-variables": "^7.16.7",
                   "@babel/helper-split-export-declaration": "^7.16.7",
-                  "@babel/parser": "^7.17.3",
-                  "@babel/types": "^7.17.0",
+                  "@babel/parser": "^7.17.10",
+                  "@babel/types": "^7.17.10",
                   "debug": "^4.1.0",
                   "globals": "^11.1.0"
                }
             },
             "@babel/types": {
-               "version": "7.17.0",
-               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-               "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+               "version": "7.17.10",
+               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.10.tgz",
+               "integrity": "sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==",
                "dev": true,
                "requires": {
                   "@babel/helper-validator-identifier": "^7.16.7",
@@ -178,14 +169,14 @@
          }
       },
       "@babel/helper-compilation-targets": {
-         "version": "7.17.7",
-         "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz",
-         "integrity": "sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==",
+         "version": "7.17.10",
+         "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.10.tgz",
+         "integrity": "sha512-gh3RxjWbauw/dFiU/7whjd0qN9K6nPJMqe6+Er7rOavFh0CQUSwhAE3IcTho2rywPJFxej6TUUHDkWcYI6gGqQ==",
          "dev": true,
          "requires": {
-            "@babel/compat-data": "^7.17.7",
+            "@babel/compat-data": "^7.17.10",
             "@babel/helper-validator-option": "^7.16.7",
-            "browserslist": "^4.17.5",
+            "browserslist": "^4.20.2",
             "semver": "^6.3.0"
          },
          "dependencies": {
@@ -207,9 +198,9 @@
          },
          "dependencies": {
             "@babel/types": {
-               "version": "7.17.0",
-               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-               "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+               "version": "7.17.10",
+               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.10.tgz",
+               "integrity": "sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==",
                "dev": true,
                "requires": {
                   "@babel/helper-validator-identifier": "^7.16.7",
@@ -248,9 +239,9 @@
          },
          "dependencies": {
             "@babel/types": {
-               "version": "7.17.0",
-               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-               "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+               "version": "7.17.10",
+               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.10.tgz",
+               "integrity": "sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==",
                "dev": true,
                "requires": {
                   "@babel/helper-validator-identifier": "^7.16.7",
@@ -269,9 +260,9 @@
          },
          "dependencies": {
             "@babel/types": {
-               "version": "7.17.0",
-               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-               "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+               "version": "7.17.10",
+               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.10.tgz",
+               "integrity": "sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==",
                "dev": true,
                "requires": {
                   "@babel/helper-validator-identifier": "^7.16.7",
@@ -306,34 +297,24 @@
                }
             },
             "@babel/generator": {
-               "version": "7.17.7",
-               "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
-               "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+               "version": "7.17.10",
+               "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.10.tgz",
+               "integrity": "sha512-46MJZZo9y3o4kmhBVc7zW7i8dtR1oIK/sdO5NcfcZRhTGYi+KKJRtHNgsU6c4VUcJmUNV/LQdebD/9Dlv4K+Tg==",
                "dev": true,
                "requires": {
-                  "@babel/types": "^7.17.0",
-                  "jsesc": "^2.5.1",
-                  "source-map": "^0.5.0"
+                  "@babel/types": "^7.17.10",
+                  "@jridgewell/gen-mapping": "^0.1.0",
+                  "jsesc": "^2.5.1"
                }
             },
             "@babel/helper-function-name": {
-               "version": "7.16.7",
-               "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
-               "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+               "version": "7.17.9",
+               "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
+               "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
                "dev": true,
                "requires": {
-                  "@babel/helper-get-function-arity": "^7.16.7",
                   "@babel/template": "^7.16.7",
-                  "@babel/types": "^7.16.7"
-               }
-            },
-            "@babel/helper-get-function-arity": {
-               "version": "7.16.7",
-               "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
-               "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
-               "dev": true,
-               "requires": {
-                  "@babel/types": "^7.16.7"
+                  "@babel/types": "^7.17.0"
                }
             },
             "@babel/helper-split-export-declaration": {
@@ -346,9 +327,9 @@
                }
             },
             "@babel/highlight": {
-               "version": "7.16.10",
-               "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-               "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+               "version": "7.17.9",
+               "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+               "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
                "dev": true,
                "requires": {
                   "@babel/helper-validator-identifier": "^7.16.7",
@@ -357,9 +338,9 @@
                }
             },
             "@babel/parser": {
-               "version": "7.17.8",
-               "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
-               "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
+               "version": "7.17.10",
+               "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.10.tgz",
+               "integrity": "sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==",
                "dev": true
             },
             "@babel/template": {
@@ -374,27 +355,27 @@
                }
             },
             "@babel/traverse": {
-               "version": "7.17.3",
-               "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
-               "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+               "version": "7.17.10",
+               "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.10.tgz",
+               "integrity": "sha512-VmbrTHQteIdUUQNTb+zE12SHS/xQVIShmBPhlNP12hD5poF2pbITW1Z4172d03HegaQWhLffdkRJYtAzp0AGcw==",
                "dev": true,
                "requires": {
                   "@babel/code-frame": "^7.16.7",
-                  "@babel/generator": "^7.17.3",
+                  "@babel/generator": "^7.17.10",
                   "@babel/helper-environment-visitor": "^7.16.7",
-                  "@babel/helper-function-name": "^7.16.7",
+                  "@babel/helper-function-name": "^7.17.9",
                   "@babel/helper-hoist-variables": "^7.16.7",
                   "@babel/helper-split-export-declaration": "^7.16.7",
-                  "@babel/parser": "^7.17.3",
-                  "@babel/types": "^7.17.0",
+                  "@babel/parser": "^7.17.10",
+                  "@babel/types": "^7.17.10",
                   "debug": "^4.1.0",
                   "globals": "^11.1.0"
                }
             },
             "@babel/types": {
-               "version": "7.17.0",
-               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-               "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+               "version": "7.17.10",
+               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.10.tgz",
+               "integrity": "sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==",
                "dev": true,
                "requires": {
                   "@babel/helper-validator-identifier": "^7.16.7",
@@ -413,9 +394,9 @@
          },
          "dependencies": {
             "@babel/types": {
-               "version": "7.17.0",
-               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-               "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+               "version": "7.17.10",
+               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.10.tgz",
+               "integrity": "sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==",
                "dev": true,
                "requires": {
                   "@babel/helper-validator-identifier": "^7.16.7",
@@ -446,13 +427,13 @@
          "dev": true
       },
       "@babel/helpers": {
-         "version": "7.17.8",
-         "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.8.tgz",
-         "integrity": "sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==",
+         "version": "7.17.9",
+         "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.9.tgz",
+         "integrity": "sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==",
          "dev": true,
          "requires": {
             "@babel/template": "^7.16.7",
-            "@babel/traverse": "^7.17.3",
+            "@babel/traverse": "^7.17.9",
             "@babel/types": "^7.17.0"
          },
          "dependencies": {
@@ -466,34 +447,24 @@
                }
             },
             "@babel/generator": {
-               "version": "7.17.7",
-               "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
-               "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+               "version": "7.17.10",
+               "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.10.tgz",
+               "integrity": "sha512-46MJZZo9y3o4kmhBVc7zW7i8dtR1oIK/sdO5NcfcZRhTGYi+KKJRtHNgsU6c4VUcJmUNV/LQdebD/9Dlv4K+Tg==",
                "dev": true,
                "requires": {
-                  "@babel/types": "^7.17.0",
-                  "jsesc": "^2.5.1",
-                  "source-map": "^0.5.0"
+                  "@babel/types": "^7.17.10",
+                  "@jridgewell/gen-mapping": "^0.1.0",
+                  "jsesc": "^2.5.1"
                }
             },
             "@babel/helper-function-name": {
-               "version": "7.16.7",
-               "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
-               "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+               "version": "7.17.9",
+               "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
+               "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
                "dev": true,
                "requires": {
-                  "@babel/helper-get-function-arity": "^7.16.7",
                   "@babel/template": "^7.16.7",
-                  "@babel/types": "^7.16.7"
-               }
-            },
-            "@babel/helper-get-function-arity": {
-               "version": "7.16.7",
-               "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
-               "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
-               "dev": true,
-               "requires": {
-                  "@babel/types": "^7.16.7"
+                  "@babel/types": "^7.17.0"
                }
             },
             "@babel/helper-split-export-declaration": {
@@ -506,9 +477,9 @@
                }
             },
             "@babel/highlight": {
-               "version": "7.16.10",
-               "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-               "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+               "version": "7.17.9",
+               "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+               "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
                "dev": true,
                "requires": {
                   "@babel/helper-validator-identifier": "^7.16.7",
@@ -517,9 +488,9 @@
                }
             },
             "@babel/parser": {
-               "version": "7.17.8",
-               "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
-               "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
+               "version": "7.17.10",
+               "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.10.tgz",
+               "integrity": "sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==",
                "dev": true
             },
             "@babel/template": {
@@ -534,27 +505,27 @@
                }
             },
             "@babel/traverse": {
-               "version": "7.17.3",
-               "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
-               "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+               "version": "7.17.10",
+               "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.10.tgz",
+               "integrity": "sha512-VmbrTHQteIdUUQNTb+zE12SHS/xQVIShmBPhlNP12hD5poF2pbITW1Z4172d03HegaQWhLffdkRJYtAzp0AGcw==",
                "dev": true,
                "requires": {
                   "@babel/code-frame": "^7.16.7",
-                  "@babel/generator": "^7.17.3",
+                  "@babel/generator": "^7.17.10",
                   "@babel/helper-environment-visitor": "^7.16.7",
-                  "@babel/helper-function-name": "^7.16.7",
+                  "@babel/helper-function-name": "^7.17.9",
                   "@babel/helper-hoist-variables": "^7.16.7",
                   "@babel/helper-split-export-declaration": "^7.16.7",
-                  "@babel/parser": "^7.17.3",
-                  "@babel/types": "^7.17.0",
+                  "@babel/parser": "^7.17.10",
+                  "@babel/types": "^7.17.10",
                   "debug": "^4.1.0",
                   "globals": "^11.1.0"
                }
             },
             "@babel/types": {
-               "version": "7.17.0",
-               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-               "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+               "version": "7.17.10",
+               "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.10.tgz",
+               "integrity": "sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==",
                "dev": true,
                "requires": {
                   "@babel/helper-validator-identifier": "^7.16.7",
@@ -1054,9 +1025,9 @@
                }
             },
             "graceful-fs": {
-               "version": "4.2.9",
-               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-               "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
+               "version": "4.2.10",
+               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+               "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
                "dev": true
             },
             "jsonfile": {
@@ -1349,22 +1320,38 @@
          "integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==",
          "dev": true
       },
+      "@jridgewell/gen-mapping": {
+         "version": "0.1.1",
+         "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+         "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+         "dev": true,
+         "requires": {
+            "@jridgewell/set-array": "^1.0.0",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+         }
+      },
       "@jridgewell/resolve-uri": {
-         "version": "3.0.5",
-         "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-         "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+         "version": "3.0.7",
+         "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
+         "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+         "dev": true
+      },
+      "@jridgewell/set-array": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
+         "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
          "dev": true
       },
       "@jridgewell/sourcemap-codec": {
-         "version": "1.4.11",
-         "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-         "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+         "version": "1.4.13",
+         "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
+         "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
          "dev": true
       },
       "@jridgewell/trace-mapping": {
-         "version": "0.3.4",
-         "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-         "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+         "version": "0.3.13",
+         "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
+         "integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
          "dev": true,
          "requires": {
             "@jridgewell/resolve-uri": "^3.0.3",
@@ -1444,9 +1431,9 @@
          }
       },
       "@silvermine/standardization": {
-         "version": "1.3.0",
-         "resolved": "https://registry.npmjs.org/@silvermine/standardization/-/standardization-1.3.0.tgz",
-         "integrity": "sha512-+XasfnVqTlAptVODZ5sx0pY6/Xjt8SuZtd4bLcNTBDj+/ne5SwXgxytMSMSS+EffxSThtT7XZZ0Rf7qVPtxxvw==",
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/@silvermine/standardization/-/standardization-2.0.0.tgz",
+         "integrity": "sha512-F1kVMa6EeTrN3xRM1FkEwjJw8lE2qp0Dvpfrtjg7F43Msm+Vv0fnwnygcjSzEzFNaVrPGHptugiod+u1U8+JFA==",
          "dev": true,
          "requires": {
             "@commitlint/cli": "12.1.1",
@@ -1458,10 +1445,7 @@
             "conventional-changelog-conventionalcommits": "4.6.3",
             "conventional-recommended-bump": "6.1.0",
             "git-semver-tags": "4.1.1",
-            "grunt-markdownlint": "2.9.0",
-            "grunt-stylelint": "0.16.0",
-            "markdownlint": "0.19.0",
-            "markdownlint-cli": "0.28.1",
+            "markdownlint-cli": "0.31.1",
             "semver": "7.3.5",
             "stylelint": "13.13.1",
             "stylelint-config-standard": "22.0.0",
@@ -1517,12 +1501,6 @@
                "version": "1.1.4",
                "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
                "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-               "dev": true
-            },
-            "commander": {
-               "version": "9.0.0",
-               "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
-               "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
                "dev": true
             },
             "find-up": {
@@ -1851,12 +1829,12 @@
          }
       },
       "@stylelint/postcss-css-in-js": {
-         "version": "0.37.2",
-         "resolved": "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.2.tgz",
-         "integrity": "sha512-nEhsFoJurt8oUmieT8qy4nk81WRHmJynmVwn/Vts08PL9fhgIsMhk1GId5yAN643OzqEEb5S/6At2TZW7pqPDA==",
+         "version": "0.37.3",
+         "resolved": "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.3.tgz",
+         "integrity": "sha512-scLk3cSH1H9KggSniseb2KNAU5D9FWc3H7BxCSAIdtU9OWIyw0zkEZ9qEKHryRM+SExYXRKNb7tOOVNAsQ3iwg==",
          "dev": true,
          "requires": {
-            "@babel/core": ">=7.9.0"
+            "@babel/core": "^7.17.9"
          }
       },
       "@stylelint/postcss-markdown": {
@@ -2456,15 +2434,15 @@
          "dev": true
       },
       "browserslist": {
-         "version": "4.20.2",
-         "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-         "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+         "version": "4.20.3",
+         "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+         "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
          "dev": true,
          "requires": {
-            "caniuse-lite": "^1.0.30001317",
-            "electron-to-chromium": "^1.4.84",
+            "caniuse-lite": "^1.0.30001332",
+            "electron-to-chromium": "^1.4.118",
             "escalade": "^3.1.1",
-            "node-releases": "^2.0.2",
+            "node-releases": "^2.0.3",
             "picocolors": "^1.0.0"
          }
       },
@@ -2561,9 +2539,9 @@
          }
       },
       "caniuse-lite": {
-         "version": "1.0.30001320",
-         "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001320.tgz",
-         "integrity": "sha512-MWPzG54AGdo3nWx7zHZTefseM5Y1ccM7hlQKHRqJkPozUaw3hNbBTMmLn16GG2FUzjR13Cr3NPfhIieX5PzXDA==",
+         "version": "1.0.30001340",
+         "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001340.tgz",
+         "integrity": "sha512-jUNz+a9blQTQVu4uFcn17uAD8IDizPzQkIKh3LCJfg9BkyIqExYYdyc/ZSlWUSKb8iYiXxKsxbv4zYSvkqjrxw==",
          "dev": true
       },
       "caseless": {
@@ -2858,6 +2836,12 @@
          "requires": {
             "delayed-stream": "~1.0.0"
          }
+      },
+      "commander": {
+         "version": "9.0.0",
+         "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+         "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
+         "dev": true
       },
       "commitizen": {
          "version": "4.0.3",
@@ -4753,9 +4737,9 @@
                }
             },
             "semver": {
-               "version": "7.3.5",
-               "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-               "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+               "version": "7.3.7",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+               "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
                "dev": true,
                "requires": {
                   "lru-cache": "^6.0.0"
@@ -5153,9 +5137,9 @@
          },
          "dependencies": {
             "domelementtype": {
-               "version": "2.2.0",
-               "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-               "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+               "version": "2.3.0",
+               "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+               "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
                "dev": true
             }
          }
@@ -5278,9 +5262,9 @@
          }
       },
       "electron-to-chromium": {
-         "version": "1.4.92",
-         "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.92.tgz",
-         "integrity": "sha512-YAVbvQIcDE/IJ/vzDMjD484/hsRbFPW2qXJPaYTfOhtligmfYEYOep+5QojpaEU9kq6bMvNeC2aG7arYvTHYsA==",
+         "version": "1.4.137",
+         "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
+         "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==",
          "dev": true
       },
       "emoji-regex": {
@@ -5299,9 +5283,9 @@
          }
       },
       "entities": {
-         "version": "2.0.3",
-         "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-         "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+         "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
          "dev": true
       },
       "error": {
@@ -6000,13 +5984,13 @@
                "dev": true
             },
             "micromatch": {
-               "version": "4.0.4",
-               "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-               "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+               "version": "4.0.5",
+               "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+               "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
                "dev": true,
                "requires": {
-                  "braces": "^3.0.1",
-                  "picomatch": "^2.2.3"
+                  "braces": "^3.0.2",
+                  "picomatch": "^2.3.1"
                }
             },
             "to-regex-range": {
@@ -7058,16 +7042,6 @@
             }
          }
       },
-      "grunt-eslint": {
-         "version": "22.0.0",
-         "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-22.0.0.tgz",
-         "integrity": "sha512-I7vIU4x/mb20fmA6TAmLx6Wzn7mfs8ZXeuk7LbP2ujKVFV7KZmJ3qXUyqe2wnD+v/74Rs5uYOZrLL8EoBmlG9Q==",
-         "dev": true,
-         "requires": {
-            "chalk": "^2.1.0",
-            "eslint": "^6.0.1"
-         }
-      },
       "grunt-exec": {
          "version": "3.0.0",
          "resolved": "https://registry.npmjs.org/grunt-exec/-/grunt-exec-3.0.0.tgz",
@@ -7205,75 +7179,6 @@
             }
          }
       },
-      "grunt-markdownlint": {
-         "version": "2.9.0",
-         "resolved": "https://registry.npmjs.org/grunt-markdownlint/-/grunt-markdownlint-2.9.0.tgz",
-         "integrity": "sha512-jLzTzNVZN/u2iblV2j+2xfJGG+Mv8NMl5CAOWNQftV7SOHnstwR/tiZPac8ZTmJFqwAqCwafIvu9wP2naAS8Og==",
-         "dev": true,
-         "requires": {
-            "markdownlint": "^0.19.0"
-         }
-      },
-      "grunt-stylelint": {
-         "version": "0.16.0",
-         "resolved": "https://registry.npmjs.org/grunt-stylelint/-/grunt-stylelint-0.16.0.tgz",
-         "integrity": "sha512-ullm0h9iCdgPEDq1TNwKL5HteXA4zke6wbYoRtsO32ATCU3zfUXmDN9unhu+joEcdgJKOPcd2+7UhRNXO1rr+w==",
-         "dev": true,
-         "requires": {
-            "chalk": "^4.1.0"
-         },
-         "dependencies": {
-            "ansi-styles": {
-               "version": "4.3.0",
-               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-               "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-               "dev": true,
-               "requires": {
-                  "color-convert": "^2.0.1"
-               }
-            },
-            "chalk": {
-               "version": "4.1.2",
-               "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-               "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-               "dev": true,
-               "requires": {
-                  "ansi-styles": "^4.1.0",
-                  "supports-color": "^7.1.0"
-               }
-            },
-            "color-convert": {
-               "version": "2.0.1",
-               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-               "dev": true,
-               "requires": {
-                  "color-name": "~1.1.4"
-               }
-            },
-            "color-name": {
-               "version": "1.1.4",
-               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-               "dev": true
-            },
-            "has-flag": {
-               "version": "4.0.0",
-               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-               "dev": true
-            },
-            "supports-color": {
-               "version": "7.2.0",
-               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-               "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-               "dev": true,
-               "requires": {
-                  "has-flag": "^4.0.0"
-               }
-            }
-         }
-      },
       "har-schema": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -7371,9 +7276,9 @@
          "dev": true
       },
       "html-tags": {
-         "version": "3.1.0",
-         "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
-         "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
+         "version": "3.2.0",
+         "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
+         "integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
          "dev": true
       },
       "htmlparser2": {
@@ -8183,9 +8088,9 @@
          "dev": true
       },
       "linkify-it": {
-         "version": "2.2.0",
-         "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-         "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+         "version": "3.0.3",
+         "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+         "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
          "dev": true,
          "requires": {
             "uc.micro": "^1.0.1"
@@ -8244,18 +8149,6 @@
          "version": "4.2.0",
          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-         "dev": true
-      },
-      "lodash.differencewith": {
-         "version": "4.5.0",
-         "resolved": "https://registry.npmjs.org/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz",
-         "integrity": "sha1-uvr7yRi1UVTheRdqALsK76rIVLc=",
-         "dev": true
-      },
-      "lodash.flatten": {
-         "version": "4.4.0",
-         "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-         "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
          "dev": true
       },
       "lodash.get": {
@@ -8457,46 +8350,50 @@
          }
       },
       "markdown-it": {
-         "version": "10.0.0",
-         "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-         "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+         "version": "12.3.2",
+         "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+         "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
          "dev": true,
          "requires": {
-            "argparse": "^1.0.7",
-            "entities": "~2.0.0",
-            "linkify-it": "^2.0.0",
+            "argparse": "^2.0.1",
+            "entities": "~2.1.0",
+            "linkify-it": "^3.0.1",
             "mdurl": "^1.0.1",
             "uc.micro": "^1.0.5"
+         },
+         "dependencies": {
+            "argparse": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+               "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+               "dev": true
+            }
          }
       },
       "markdownlint": {
-         "version": "0.19.0",
-         "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.19.0.tgz",
-         "integrity": "sha512-+MsWOnYVUH4klcKM7iRx5cno9FQMDAb6FC6mWlZkeXPwIaK6Z5Vd9VkXkykPidRqmLHU2wI+MNyfUMnUCBw3pQ==",
+         "version": "0.25.1",
+         "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.25.1.tgz",
+         "integrity": "sha512-AG7UkLzNa1fxiOv5B+owPsPhtM4D6DoODhsJgiaNg1xowXovrYgOnLqAgOOFQpWOlHFVQUzjMY5ypNNTeov92g==",
          "dev": true,
          "requires": {
-            "markdown-it": "10.0.0"
+            "markdown-it": "12.3.2"
          }
       },
       "markdownlint-cli": {
-         "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.28.1.tgz",
-         "integrity": "sha512-RBKtRRBzcuAF/H5wMSzb4zvEtbUkyYNEeaDtlQkyH9SoHWPL01emJ2Wrx6NEOa1ZDGwB+seBGvE157Qzc/t/vA==",
+         "version": "0.31.1",
+         "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.31.1.tgz",
+         "integrity": "sha512-keIOMwQn+Ch7MoBwA+TdkyVMuxAeZFEGmIIlvwgV0Z1TGS5MxPnRr29XCLhkNzCHU+uNKGjU+VEjLX+Z9kli6g==",
          "dev": true,
          "requires": {
-            "commander": "~8.0.0",
-            "deep-extend": "~0.6.0",
-            "get-stdin": "~8.0.0",
-            "glob": "~7.1.7",
-            "ignore": "~5.1.8",
+            "commander": "~9.0.0",
+            "get-stdin": "~9.0.0",
+            "glob": "~7.2.0",
+            "ignore": "~5.2.0",
             "js-yaml": "^4.1.0",
             "jsonc-parser": "~3.0.0",
-            "lodash.differencewith": "~4.5.0",
-            "lodash.flatten": "~4.4.0",
-            "markdownlint": "~0.23.1",
-            "markdownlint-rule-helpers": "~0.14.0",
-            "minimatch": "~3.0.4",
-            "minimist": "~1.2.5",
+            "markdownlint": "~0.25.1",
+            "markdownlint-rule-helpers": "~0.16.0",
+            "minimatch": "~3.0.5",
             "run-con": "~1.2.10"
          },
          "dependencies": {
@@ -8506,28 +8403,16 @@
                "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
                "dev": true
             },
-            "commander": {
-               "version": "8.0.0",
-               "resolved": "https://registry.npmjs.org/commander/-/commander-8.0.0.tgz",
-               "integrity": "sha512-Xvf85aAtu6v22+E5hfVoLHqyul/jyxh91zvqk/ioJTQuJR7Z78n7H558vMPKanPSRgIEeZemT92I2g9Y8LPbSQ==",
-               "dev": true
-            },
-            "entities": {
-               "version": "2.1.0",
-               "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-               "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-               "dev": true
-            },
             "get-stdin": {
-               "version": "8.0.0",
-               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
-               "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+               "version": "9.0.0",
+               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
+               "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
                "dev": true
             },
             "glob": {
-               "version": "7.1.7",
-               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-               "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+               "version": "7.2.0",
+               "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+               "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
                "dev": true,
                "requires": {
                   "fs.realpath": "^1.0.0",
@@ -8539,9 +8424,9 @@
                }
             },
             "ignore": {
-               "version": "5.1.9",
-               "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-               "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+               "version": "5.2.0",
+               "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+               "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
                "dev": true
             },
             "js-yaml": {
@@ -8553,49 +8438,21 @@
                   "argparse": "^2.0.1"
                }
             },
-            "linkify-it": {
-               "version": "3.0.3",
-               "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-               "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+            "minimatch": {
+               "version": "3.0.8",
+               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+               "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
                "dev": true,
                "requires": {
-                  "uc.micro": "^1.0.1"
+                  "brace-expansion": "^1.1.7"
                }
-            },
-            "markdown-it": {
-               "version": "12.0.4",
-               "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.0.4.tgz",
-               "integrity": "sha512-34RwOXZT8kyuOJy25oJNJoulO8L0bTHYWXcdZBYZqFnjIy3NgjeoM3FmPXIOFQ26/lSHYMr8oc62B6adxXcb3Q==",
-               "dev": true,
-               "requires": {
-                  "argparse": "^2.0.1",
-                  "entities": "~2.1.0",
-                  "linkify-it": "^3.0.1",
-                  "mdurl": "^1.0.1",
-                  "uc.micro": "^1.0.5"
-               }
-            },
-            "markdownlint": {
-               "version": "0.23.1",
-               "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.23.1.tgz",
-               "integrity": "sha512-iOEwhDfNmq2IJlaA8mzEkHYUi/Hwoa6Ss+HO5jkwUR6wQ4quFr0WzSx+Z9rsWZKUaPbyirIdL1zGmJRkWawr4Q==",
-               "dev": true,
-               "requires": {
-                  "markdown-it": "12.0.4"
-               }
-            },
-            "minimist": {
-               "version": "1.2.6",
-               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-               "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-               "dev": true
             }
          }
       },
       "markdownlint-rule-helpers": {
-         "version": "0.14.0",
-         "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.14.0.tgz",
-         "integrity": "sha512-vRTPqSU4JK8vVXmjICHSBhwXUvbfh/VJo+j7hvxqe15tLJyomv3FLgFdFgb8kpj0Fe8SsJa/TZUAXv7/sN+N7A==",
+         "version": "0.16.0",
+         "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.16.0.tgz",
+         "integrity": "sha512-oEacRUVeTJ5D5hW1UYd2qExYI0oELdYK72k1TKGvIeYJIbqQWAz476NAc7LNixSySUhcNl++d02DvX0ccDk9/w==",
          "dev": true
       },
       "mathml-tag-names": {
@@ -9233,9 +9090,9 @@
          }
       },
       "node-releases": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-         "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+         "version": "2.0.4",
+         "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
+         "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
          "dev": true
       },
       "nopt": {
@@ -11055,9 +10912,9 @@
          }
       },
       "postcss-selector-parser": {
-         "version": "6.0.9",
-         "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
-         "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
+         "version": "6.0.10",
+         "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+         "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
          "dev": true,
          "requires": {
             "cssesc": "^3.0.0",
@@ -12592,13 +12449,13 @@
                }
             },
             "micromatch": {
-               "version": "4.0.4",
-               "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-               "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+               "version": "4.0.5",
+               "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+               "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
                "dev": true,
                "requires": {
-                  "braces": "^3.0.1",
-                  "picomatch": "^2.2.3"
+                  "braces": "^3.0.2",
+                  "picomatch": "^2.3.1"
                }
             },
             "minimist-options": {
@@ -12778,9 +12635,9 @@
                }
             },
             "semver": {
-               "version": "7.3.5",
-               "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-               "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+               "version": "7.3.7",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+               "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
                "dev": true,
                "requires": {
                   "lru-cache": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
       "prepare": "grunt build",
       "test": "check-node-version --npm 6.14.12 && TS_NODE_PROJECT='tests/tsconfig.json' TS_NODE_FILES=true nyc mocha",
       "commitlint": "commitlint --from 86324da",
+      "eslint": "eslint '{,!(node_modules|dist)/**/}*.{js,ts}'",
+      "markdownlint": "markdownlint -c .markdownlint.json -i CHANGELOG.md '{,!(node_modules)/**/}*.md'",
+      "standards": "tsc -p tsconfig.json --pretty && npm run markdownlint && npm run eslint",
       "release:preview": "node ./node_modules/@silvermine/standardization/scripts/release.js preview",
       "release:prep-changelog": "node ./node_modules/@silvermine/standardization/scripts/release.js prep-changelog",
       "release:finalize": "node ./node_modules/@silvermine/standardization/scripts/release.js finalize"
@@ -26,7 +29,7 @@
    "devDependencies": {
       "@silvermine/chai-strictly-equal": "1.1.0",
       "@silvermine/eslint-config": "3.1.0-beta.0",
-      "@silvermine/standardization": "1.3.0",
+      "@silvermine/standardization": "2.0.0",
       "@silvermine/typescript-config": "0.9.0",
       "@types/aws-lambda": "8.10.17",
       "@types/chai": "4.1.7",
@@ -45,7 +48,6 @@
       "grunt-concurrent": "2.3.1",
       "grunt-contrib-clean": "2.0.0",
       "grunt-contrib-watch": "1.1.0",
-      "grunt-eslint": "22.0.0",
       "grunt-exec": "3.0.0",
       "mocha": "8.4.0",
       "nyc": "13.1.0",


### PR DESCRIPTION
Upgrades Standardization to v2, removes `grunt-standards` and related configuration & dependencies.