### PR TITLE
refactor: Use await so the handler appears in the stack trace on error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,8 +27,8 @@ export {
  * ```
  */
 export function createAsyncHandler(app: Application): (event: RequestEvent, context: Context) => Promise<ResponseResult> {
-   return (event: RequestEvent, context: Context): Promise<ResponseResult> => {
-      return app.runAsync(event, context);
+   return async (event: RequestEvent, context: Context): Promise<ResponseResult> => {
+      return await app.runAsync(event, context);
    };
 }
 


### PR DESCRIPTION
Updated createAsyncHandler to use return await app.runAsync(event, context) so the handler frame is preserved in async stack traces when errors occur.